### PR TITLE
Normalize URLs

### DIFF
--- a/_architecture/babelfish-query-handling.md
+++ b/_architecture/babelfish-query-handling.md
@@ -2,8 +2,6 @@
 layout: default
 title: Query Handling
 nav_order: 9
-has_children: false
-permalink: /docs/architecture/query-handling
 ---
 
 ## Babelfish query handling

--- a/_architecture/compatibility.md
+++ b/_architecture/compatibility.md
@@ -2,8 +2,6 @@
 layout: default
 title: Compatibility
 nav_order: 9
-has_children: false
-permalink: /docs/architecture/compatibility
 ---
 
 # Babelfish Compatibility

--- a/_architecture/extensions.md
+++ b/_architecture/extensions.md
@@ -2,8 +2,6 @@
 layout: default
 title: Extensions
 nav_order: 8
-has_children: false
-permalink: /docs/architecture/extensions
 ---
 
 Given below is the overall strategy for Extensions. Team is in the process of creating these extensions.

--- a/_architecture/handling-tsql.md
+++ b/_architecture/handling-tsql.md
@@ -2,8 +2,6 @@
 layout: default
 title: Handling Transact-SQL
 nav_order: 10
-has_children: false
-permalink: /docs/architecture/handling-tsql
 ---
 
 ## Handling Transact-SQL

--- a/_architecture/high-level-design.md
+++ b/_architecture/high-level-design.md
@@ -2,8 +2,6 @@
 layout: default
 title: High-Level Design
 nav_order: 4
-has_children: false
-permalink: /docs/architecture/high-level-design
 use_mermaid: true
 ---
 

--- a/_architecture/locales.md
+++ b/_architecture/locales.md
@@ -1,9 +1,7 @@
 ---
 layout: default
-title: Locales and language support  
+title: Locales and Language Support  
 nav_order: 7
-has_children: false
-permalink: /docs/architecture/locales
 ---
 
 ## Locales and language support

--- a/_architecture/missing-features.md
+++ b/_architecture/missing-features.md
@@ -2,8 +2,6 @@
 layout: default
 title: Missing Features
 nav_order: 6
-has_children: false
-permalink: /docs/architecture/missing-features
 ---
 
 ## Managing differences in behavior

--- a/_architecture/protocol-hooks.md
+++ b/_architecture/protocol-hooks.md
@@ -3,8 +3,6 @@ layout: default
 title: Protocol Hooks
 nav_order: 5
 has_children: false
-permalink: /docs/architecture/protocol-hooks
-use_mermaid: true
 ---
 
 ## Protocol hooks

--- a/_architecture/single-multiple.md
+++ b/_architecture/single-multiple.md
@@ -1,9 +1,7 @@
 ---
 layout: default
-title: Single vs. multiple instances
+title: Single vs. Multiple Instances
 nav_order: 11
-has_children: false
-permalink: /docs/architecture/single-multiple
 ---
 ## Single vs. multiple instances
 

--- a/_architecture/system-views.md
+++ b/_architecture/system-views.md
@@ -1,9 +1,7 @@
 ---
 layout: default
-title: System views
+title: System Views
 nav_order: 13
-has_children: false
-permalink: /docs/architecture/system-views
 ---
 
 ## Babelfish system views 

--- a/_architecture/tds-protocol.md
+++ b/_architecture/tds-protocol.md
@@ -1,9 +1,7 @@
 ---
 layout: default
-title: The TDS wire protocol 
+title: The TDS Wire Protocol 
 nav_order: 8
-has_children: false
-permalink: /docs/architecture/tds-protocol
 ---
 
 ## The TDS wire protocol

--- a/_config.yml
+++ b/_config.yml
@@ -76,23 +76,22 @@ defaults:
 collections:
   # Define a collection named "tests", its documents reside in the "_tests" directory
   architecture:
-    permalink: /:collection/:path/
+    permalink: /docs/:collection/:path/
     output: true
   installation:
-    permalink: /:collection/:path/
+    permalink: /docs/installation-guide/:path/
     output: true
   connecting:
-    permalink: /:collection/:path/
+    permalink: /docs/connecting-to-babelfish/:path/
     output: true
   docs:
+    permalink: /:collection/:path/
     output: true
   events:
     output: true
   artifacts:
     output: true
   versions:
-    output: true
-  docs:
     output: true
   faqs:
     output: true
@@ -103,6 +102,7 @@ paginate_path: "/blog/page:num/"
 just_the_docs:
   # Define the collections used in the theme
   collections:
+    docs:
     architecture:
       name: Babelfish Architecture
       # nav_exclude: true
@@ -181,3 +181,4 @@ exclude:
   - vendor/gems/
   - vendor/ruby/
   - README.md
+  - .idea/

--- a/_connecting/c.md
+++ b/_connecting/c.md
@@ -2,8 +2,6 @@
 layout: default
 title: C
 nav_order: 18
-has_children: false
-permalink: /docs/connecting-to-babelfish/c
 ---
 
 ## Preparing to write C code 

--- a/_connecting/command-line.md
+++ b/_connecting/command-line.md
@@ -2,8 +2,6 @@
 layout: default
 title: Command Line
 nav_order: 14
-has_children: false
-permalink: /docs/connecting-to-babelfish/command-line
 ---
 
 ## Using the command line to work with Babelfish

--- a/_connecting/csharp.md
+++ b/_connecting/csharp.md
@@ -2,8 +2,6 @@
 layout: default
 title: C#
 nav_order: 15
-has_children: false
-permalink: /docs/connecting-to-babelfish/csharp
 ---
 
 ## Programming in C#

--- a/_connecting/java.md
+++ b/_connecting/java.md
@@ -2,8 +2,6 @@
 layout: default
 title: Java
 nav_order: 16
-has_children: false
-permalink: /docs/connecting-to-babelfish/java
 ---
 
 ## Utilizing JDBC

--- a/_connecting/other-tools.md
+++ b/_connecting/other-tools.md
@@ -2,8 +2,6 @@
 layout: default
 title: Other tools
 nav_order: 19
-has_children: false
-permalink: /docs/connecting-to-babelfish/other-tools
 ---
 
 ## Using other tools

--- a/_connecting/python.md
+++ b/_connecting/python.md
@@ -2,8 +2,6 @@
 layout: default
 title: Python
 nav_order: 17
-has_children: false
-permalink: /docs/connecting-to-babelfish/python
 ---
 
 ## Using Python with Babelfish

--- a/_docs/.gitignore
+++ b/_docs/.gitignore
@@ -1,7 +1,0 @@
-_site
-.sass-cache
-.jekyll-metadata
-.DS_Store
-Gemfile.lock
-.idea
-.jekyll-cache

--- a/_docs/index.md
+++ b/_docs/index.md
@@ -1,9 +1,9 @@
 ---
 layout: default
 title: Get started
-nav_order: 1
 redirect_from: /404.html
-permalink: /docs
+nav_exclude: true
+permalink: /docs/
 ---
 
 # Babelfish for PostgreSQL documentation

--- a/_docs/limitations-of-babelfish.md
+++ b/_docs/limitations-of-babelfish.md
@@ -2,8 +2,6 @@
 layout: default
 title: Limitations of Babelfish
 nav_order: 2
-has_children: false
-permalink: /docs/limitations-of-babelfish
 ---
 
 ## T-SQL limitations

--- a/_docs/migration.markdown
+++ b/_docs/migration.markdown
@@ -3,7 +3,6 @@ layout: default
 title: Migrating to Babelfish
 nav_order: 3
 has_children: false
-permalink: /docs/migration
 ---
 
 ## Migrating to Babelfish

--- a/_docs/vision.md
+++ b/_docs/vision.md
@@ -2,8 +2,6 @@
 layout: default
 title: Vision for Babelfish
 nav_order: 1
-has_children: false
-permalink: /docs/vision
 ---
 
 ## Vision of Babelfish

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,4 +1,4 @@
-{% if page.path contains 'docs' or page.permalink contains 'docs'  %}
+{% if page.path contains 'docs' or page.permalink contains 'docs' or page.url contains 'docs'  %}
   <head>
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=Edge">

--- a/_installation/compiling-babelfish-from-source.md
+++ b/_installation/compiling-babelfish-from-source.md
@@ -1,9 +1,7 @@
 ---
 layout: default
-title: Build from source code
+title: Build from Source Code
 nav_order: 13
-has_children: false
-permalink: /docs/installation-guide/build-from-source
 ---
 
 # Compiling Babelfish from source

--- a/_installation/configuration.md
+++ b/_installation/configuration.md
@@ -2,8 +2,6 @@
 layout: default
 title: Configuration
 nav_order: 14
-has_children: false
-permalink: /docs/installation-guide/configuration
 ---
 
 ## Configuring Babelfish

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,7 +1,7 @@
 ---
 layout: table_wrappers
 ---
-{% if page.path contains 'docs' or page.permalink contains 'docs'  %}
+{% if page.path contains 'docs' or page.permalink contains 'docs' or page.url contains 'docs'  %}
   <!DOCTYPE html>
 
   <html lang="{{ site.lang | default: 'en-US' }}">
@@ -85,7 +85,9 @@ layout: table_wrappers
                       </li>
                     </ul>
                   {% else %}
+                    {% if collection_value.name %}
                     <div class="nav-category">{{ collection_value.name }}</div>
+                    {% endif %}
                     {% include nav.html pages=collection key=collection_key %}
                   {% endif %}
                 {% else %}

--- a/contributing.markdown
+++ b/contributing.markdown
@@ -3,7 +3,7 @@ layout: default
 title: Contributing code
 nav_order: 23
 has_children: false
-permalink: /docs/contributing
+permalink: /docs/contributing/
 footer_nav: true
 ---
 

--- a/faq.md
+++ b/faq.md
@@ -1,9 +1,9 @@
 ---
 layout: default
-title: Frequently asked questions
+title: Frequently Asked Questions
 nav_order: 22
 has_children: false
-permalink: /docs/faq
+permalink: /docs/faq/
 footer_nav: true
 ---
 

--- a/security.md
+++ b/security.md
@@ -3,7 +3,7 @@ layout: default
 title: Security
 nav_order: 21
 has_children: false
-permalink: /docs/security
+permalink: /docs/security/
 footer_nav: true
 ---
 

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -3,7 +3,7 @@ layout: default
 title: Troubleshooting
 nav_order: 20
 has_children: false
-permalink: /docs/troubleshooting
+permalink: /docs/troubleshooting/
 footer_nav: true
 ---
 


### PR DESCRIPTION
### Description
* Normalize the URLs for standard hosting; `/<path>` and `/<path>/` are served `/<path>/index.html` by web servers.
* Remove all permalinks in pages in favor of those provided in the `_config.yml` which eases the ongoing management of the content.
* Remove unnecessary `has_children: false` from pages.

Signed-off-by: Miki <mehranb@amazon.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
