### PR TITLE
Remove unnecessary `img` tag from the contributor template

### DIFF
--- a/_includes/contributor.html
+++ b/_includes/contributor.html
@@ -13,7 +13,6 @@
             <td class="photo">
                 {% if include.contributor.pic %}
                     <div class="pic" style="background-image: url({{include.contributor.pic}})">
-                        <img src="{{include.contributor.pic}}">
                     </div>
                 {% else %}
                     <div class="pic none"></div>


### PR DESCRIPTION
Signed-off-by: Miki <mehranb@amazon.com>

### Description
The photos of contributors are served as backgrounds to a div. The `img` tag was unnecessary and broke the layout o the page.



By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
