### PR TITLE
fix: make sure the footer is always at the bottom of the screen

### DIFF
--- a/_sass/_babelfishpg.scss
+++ b/_sass/_babelfishpg.scss
@@ -1,3 +1,7 @@
+[role="main"] {
+    min-height: calc(100vh - 450px);
+}
+
 dl.list-features {
     counter-reset: list-features;
     h2 {

--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -35,6 +35,7 @@ body {
     // don't activate mobile styles for larger screens
     @include respond-min(768px) {
         min-width: 768px;
+        min-height: 100vh;
     }
 }
 a {

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,4 +1,8 @@
 /* Custom CSS to override default just-the-docs styling */
+[role="main"] {
+        min-height: calc(100vh - 450px);
+}
+
 [role="banner"] {
     background: url('../images/bbfsh_header.png') center center no-repeat;
     background-size: cover;


### PR DESCRIPTION
### Description
Adjust footer location so it is always at the bottom of the screen.

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
