### PR TITLE
Improve "vision" and "contributing" doc

### DIFF
--- a/_docs/contributing.md
+++ b/_docs/contributing.md
@@ -31,14 +31,17 @@ test suite which covers a variety of scenarios. Changes made to the code should
 not break existing features. We strongly recommend running the standard tests
 before you send a pull request to development. 
 
+If you add new features, you also need to add tests for functionality.
+Patches that do not contain tests for new features will not be accepted by the
+community.
+
 
 ### Documentation and help
 
-If you add new features, you also need to add tests for functionality.
-Patches that do not contain tests for new features will not be accepted by the
-community. The same is true for missing documentation. Documenting your feature
-is as important as having working code. That's why we encourage people to properly document
-their code. If you are having language troubles, or if you need help, we recommend
+The same is true for missing documentation: feature documentation and
+explanatory source comments are as important as working code.
+That's why we encourage people to properly document their contribution.
+If you are having language troubles, or if you need help, we recommend
 reaching out to the community for help via Github.
 
 For most new features, it is generally a good idea to provide working examples.

--- a/_docs/contributing.md
+++ b/_docs/contributing.md
@@ -40,7 +40,7 @@ community.
 
 The same is true for missing documentation: feature documentation and
 explanatory source comments are as important as working code.
-That's why we encourage people to properly document their contribution.
+That's why we encourage people to properly document their contributions.
 If you are having language troubles, or if you need help, we recommend
 reaching out to the community for help via Github.
 

--- a/_docs/contributing.md
+++ b/_docs/contributing.md
@@ -31,7 +31,7 @@ test suite which covers a variety of scenarios. Changes made to the code should
 not break existing features. We strongly recommend running the tests
 before you send a pull request to development. 
 
-If you add new features, you also need to add tests for functionality.
+If you add new features, you also need to add tests for them.
 Patches that do not contain tests for new features will not be accepted by the
 community.
 

--- a/_docs/contributing.md
+++ b/_docs/contributing.md
@@ -26,9 +26,9 @@ maintenance, and make the code more readable for other community members.
 
 ### Testing and quality management
 
-Make sure that your code is properly tested. Babelfish comes with a standard
+Make sure that your code is properly tested. Babelfish comes with a
 test suite which covers a variety of scenarios. Changes made to the code should
-not break existing features. We strongly recommend running the standard tests
+not break existing features. We strongly recommend running the tests
 before you send a pull request to development. 
 
 If you add new features, you also need to add tests for functionality.

--- a/_docs/contributing.md
+++ b/_docs/contributing.md
@@ -56,9 +56,9 @@ mistakes or other problems. Positive feedback is highly appreciated, and we are
 happy if people help us to detect bugs and find other problems such as typos in
 the documentation. 
 
-To help with code review, simply check out 
+To help with code review, please check out
 [Github](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish) 
-and help with the review process. 
+and help with the review process.
 
 
 ### Avoiding license violations

--- a/_docs/vision.md
+++ b/_docs/vision.md
@@ -16,8 +16,8 @@ PostgreSQL?
 Welcome to Babelfish.  Babelfish closes the gap between PostgreSQL and
 Microsoft SQL Server by teaching PostgreSQL to speak TDS, the native
 client-server protocol of Microsoft SQL Server.  In addition, Babelfish
-implements support for Microsoft SQL Server syntax, which makes it easier to
-move to PostgreSQL.
+implements support for Microsoft SQL Server's SQL syntax, which makes it easier
+to move to PostgreSQL.
 
 However, moving applications is just one side of the equation. Migrating data
 is one thing - making sure that applications work properly is another, far

--- a/_docs/vision.md
+++ b/_docs/vision.md
@@ -14,7 +14,7 @@ is capable of speaking various protocols and presenting itself as more than just
 PostgreSQL?
 
 Welcome to Babelfish. The idea of the project is to close the gap between
-PostgreSQL and other systems by making PostgreSQL speak other protocols such as
+PostgreSQL and other systems by teaching PostgreSQL other protocols such as
 TDS, and maybe a lot more in the future. By implementing support for Microsoft
 SQL Server syntax, Babelfish makes it easier to move to PostgreSQL.
 

--- a/_docs/vision.md
+++ b/_docs/vision.md
@@ -49,14 +49,8 @@ However, we do our best to keep this list as short as humanly possible.
 If you want to find out more about limitations: We have dedicated an entire
 section to the [limitations](/docs/usage/limitations-of-babelfish).
 
-### Preparing for the future
-
-Nothing is perfect, but the community is working hard to make things
-function as smoothly as possible. Much of it works already, but more 
-work has to go into this area to be even more compatible. In other words: 
-We have an exciting future ahead. Many more features will be developed as 
-people improve the user experience, raising it to new levels. 
+### Join the Babelfish community
 
 Be part of the community and help to improve Babelfish even more.
-If you want to [contribute to Babelfish](/docs/contributing) simply reach
+If you want to [contribute to Babelfish](/docs/contributing), simply reach
 out to us.

--- a/_docs/vision.md
+++ b/_docs/vision.md
@@ -15,31 +15,31 @@ PostgreSQL?
 
 Welcome to Babelfish. The idea of the project is to close the gap between
 PostgreSQL and other systems by making PostgreSQL speak other protocols such as
-TDS, and maybe a lot more in the future. By implementing "MS SQL"-slang, we make
+TDS, and maybe a lot more in the future. By implementing "Microsoft SQL Server"-slang, we make
 it easier for people to move to PostgreSQL. 
 
 However, moving applications is just one side of the equation. Migrating data
 is one thing - making sure that applications work properly is another, far
 more important thing. In fact, migrating data to PostgreSQL can be relatively
-easy, while migration entire application stacks can be really difficult. 
+easy, while migrating entire application stacks can be really difficult.
 
 That's exactly why Babelfish is so important. It allows you to take existing
 applications, hook them up to TDS-enabled PostgreSQL and run them more quickly
 and more easily, even while some migration work might still be going on. 
 
-A second option is to move application from MS SQL to PostgreSQL without
+A second option is to move application from Microsoft SQL Server to PostgreSQL without
 touching the application at all. Why is that so important? If you get your
 source code under control, life is usually easier. But what if you want to move
 old legacy applications from Microsoft SQL Server to PostgreSQL, legacy applications which cannot be
 modified easily, because the source code is not open, is lost, or is simply too hard to
 change? Babelfish is an excellent vehicle to help in this case as well. You can
-move away from expensive MS SQL deployments without doing a painful app
+move away from expensive Microsoft SQL Server deployments without doing a painful app
 migration. Brilliant, isn't it?
 
 
 ### What Babelfish is not
 
-While Babelfish can ease a lot of the burden MS SQL users experience, it is not a drop-in
+While Babelfish can ease a lot of the burden Microsoft SQL Server users experience, it is not a drop-in
 replacement for everything. There is code (especially some server-side 
 procedures related to administration) that is not going
 to work on Babelfish. The reason is that every database engine has limitations.
@@ -47,7 +47,7 @@ The same is of course true for PostgreSQL and therefore some exotic features can
 However, we do our best to keep this list as short as humanly possible.
 
 If you want to find out more about limitations: We have dedicated an entire
-[section dealing with limitations incompatibilities](/docs/usage/limitations-of-babelfish).
+section to the [limitations](/docs/usage/limitations-of-babelfish).
 
 ### Preparing for the future
 
@@ -59,5 +59,4 @@ people improve the user experience, raising it to new levels.
 
 Be part of the community and help to improve Babelfish even more.
 If you want to [contribute to Babelfish](/docs/contributing) simply reach
-out to the community.
-
+out to us.

--- a/_docs/vision.md
+++ b/_docs/vision.md
@@ -13,10 +13,11 @@ to present itself as more than just one database? Why not create software which
 is capable of speaking various protocols and presenting itself as more than just
 PostgreSQL?
 
-Welcome to Babelfish. The idea of the project is to close the gap between
-PostgreSQL and other systems by teaching PostgreSQL other protocols such as
-TDS, and maybe a lot more in the future. By implementing support for Microsoft
-SQL Server syntax, Babelfish makes it easier to move to PostgreSQL.
+Welcome to Babelfish.  Babelfish closes the gap between PostgreSQL and
+Microsoft SQL Server by teaching PostgreSQL to speak TDS, the native
+client-server protocol of Microsoft SQL Server.  In addition, Babelfish
+implements support for Microsoft SQL Server syntax, which makes it easier to
+move to PostgreSQL.
 
 However, moving applications is just one side of the equation. Migrating data
 is one thing - making sure that applications work properly is another, far

--- a/_docs/vision.md
+++ b/_docs/vision.md
@@ -28,14 +28,10 @@ That's exactly why Babelfish is so important. It allows you to take existing
 applications, hook them up to TDS-enabled PostgreSQL and run them more quickly
 and more easily, even while some migration work might still be going on. 
 
-A second option is to move application from Microsoft SQL Server to PostgreSQL without
-touching the application at all. Why is that so important? If you get your
-source code under control, life is usually easier. But what if you want to move
-old legacy applications from Microsoft SQL Server to PostgreSQL, legacy applications which cannot be
-modified easily, because the source code is not open, is lost, or is simply too hard to
-change? Babelfish is an excellent vehicle to help in this case as well. You can
-move away from expensive Microsoft SQL Server deployments without doing a painful app
-migration. Brilliant, isn't it?
+If you are stuck with a legacy application, where the source code is not
+available or too hard to modify for technical or financial reasons, Babelfish
+can provide an easy way out.  The flexibility and cost savings offered by
+open source software projects like PostgreSQL with Babelfish can be significant.
 
 
 ### What Babelfish is not

--- a/_docs/vision.md
+++ b/_docs/vision.md
@@ -49,5 +49,4 @@ section to the [limitations](/docs/usage/limitations-of-babelfish).
 ### Join the Babelfish community
 
 Be part of the community and help to improve Babelfish.
-If you want to [contribute to Babelfish](/docs/contributing), simply reach
-out to us.
+If you want to [contribute to Babelfish](/docs/contributing), you are welcome.

--- a/_docs/vision.md
+++ b/_docs/vision.md
@@ -51,6 +51,6 @@ section to the [limitations](/docs/usage/limitations-of-babelfish).
 
 ### Join the Babelfish community
 
-Be part of the community and help to improve Babelfish even more.
+Be part of the community and help to improve Babelfish.
 If you want to [contribute to Babelfish](/docs/contributing), simply reach
 out to us.

--- a/_docs/vision.md
+++ b/_docs/vision.md
@@ -15,8 +15,8 @@ PostgreSQL?
 
 Welcome to Babelfish. The idea of the project is to close the gap between
 PostgreSQL and other systems by making PostgreSQL speak other protocols such as
-TDS, and maybe a lot more in the future. By implementing "Microsoft SQL Server"-slang, we make
-it easier for people to move to PostgreSQL. 
+TDS, and maybe a lot more in the future. By implementing support for Microsoft
+SQL Server syntax, Babelfish makes it easier to move to PostgreSQL.
 
 However, moving applications is just one side of the equation. Migrating data
 is one thing - making sure that applications work properly is another, far

--- a/_docs/vision.md
+++ b/_docs/vision.md
@@ -26,11 +26,11 @@ easy, while migrating entire application stacks can be really difficult.
 
 That's exactly why Babelfish is so important. It allows you to take existing
 applications, hook them up to TDS-enabled PostgreSQL and run them more quickly
-and more easily, even while some migration work might still be going on. 
+and easily, even while some migration work is still going on.
 
-If you are stuck with a legacy application, where the source code is not
-available or too hard to modify for technical or financial reasons, Babelfish
-can provide an easy way out.  The flexibility and cost savings offered by
+If you are stuck with a legacy application where the source code is not
+available or is too hard to modify for technical or financial reasons, Babelfish
+provides an easy way out.  The flexibility and cost savings offered by
 open source software projects like PostgreSQL with Babelfish can be significant.
 
 
@@ -49,4 +49,4 @@ section to the [limitations](/docs/usage/limitations-of-babelfish).
 ### Join the Babelfish community
 
 Be part of the community and help to improve Babelfish.
-If you want to [contribute to Babelfish](/docs/contributing), you are welcome.
+If you want to [contribute to Babelfish](/docs/contributing), you're welcome to.


### PR DESCRIPTION
In "vision":

- Fix bad grammar.

- Spell out the product instead of abbreviating it as "MS SQL".

In "contributing":

- Rewrite the requirement to add documentation with your contribution and move the parts that deal with tests to the preceding section.

Per request from @susanmdouglas-aws.
This closes #89.