### PR TITLE
Replace "babelfish_money" documentation with a link

### DIFF
--- a/_internals/software-architecture.md
+++ b/_internals/software-architecture.md
@@ -110,18 +110,11 @@ types which behave differently. Here is a complete list of these types:
 
 In addition to the core data types outlined in the previous section, there is
 one more data type which is packaged into a separate extension for licensing
-reasons: `FIXEDDECIMAL`. The length of the data type is 8 bytes. It
-is basically a subset of the standard PostgreSQL `NUMERIC` data types
-aligned as a fixed-length type to dramatically improve performance.
+reasons: `fixeddecimal`.
 
-What does the word &ldquo;subset&rdquo; mean in this context?
-
-- The precision and scale are limited to (17, 2).
-- `FIXEDDECIMAL` always rounds towards zero and not to the nearest number.
-- `NaN` (&ldquo;not a number&rdquo;) is not supported.
-- Changing the precision will lead to an error.  
-  For example: `SELECT '123.223'::FIXEDDECIMAL(4,1)` will
-  error out, which is not the case with `NUMERIC`.
+See the
+[documentation of the original software](https://github.com/2ndQuadrant/fixeddecimal/blob/master/README.md)
+for usage instructions and other information.
 
 #### `babelfishpg_tds`: TDS protocol extension
 


### PR DESCRIPTION
Since this is just a copy of the 2ndQuadrant software, it is silly to add usage instructions and internal details.

Rather, point to the original documentation.

This closes #103.

Not that this commit doesn't touch any of the other problems in the data type documentation, in order to reduce merge conflicts
with a prospective patch that addresses #102 once we have the required information.