### PR TITLE
Add a link to finish Babelfish setup

### DIFF
--- a/_installation/compiling-babelfish-from-source.md
+++ b/_installation/compiling-babelfish-from-source.md
@@ -284,3 +284,6 @@ Now you can start Babelfish by running the command:
 ``` sh
 $INSTALLATION_PATH/bin/pg_ctl -D /usr/local/pgsql/data start
 ```
+
+To finish the Babelfish setup, continue [here](/docs/installation/single-multiple)
+with the initialization.


### PR DESCRIPTION
When people want to install Babelfish, they will read the "compilation from source" page.  However, that page does not mention that you need to initialze Babelfish.
The reader is left thinking that Babelfish is ready to use once the server is started.

Add a link to the "single-db vs. multi-db setup" page.