### PR TITLE
Tweaked wording in getting_help.md

### DIFF
--- a/_faq/getting_help.md
+++ b/_faq/getting_help.md
@@ -4,8 +4,8 @@ title: Getting help
 nav_order: 1
 ---
 
-If you want to place a question, do it so in the [Babelfish Extensions Repository][https://github.com/babelfish-for-postgresql/babelfish_extensions/issues/new/choose], using the Question Issue templace. 
+To send a question to the Babelfish team, please visit the [Babelfish Extensions Repository](https://github.com/babelfish-for-postgresql/babelfish_extensions/issues/new/choose). Select the `Get Started` button to the right of `Babelfish for PostgreSQL Question` to access the `Question` template. 
 
 We are eager to fix bugs and to provide you with some assistance.
 
-In case you have found bugs or want to make suggestions, we are open to all kinds of contributions to improve the product. Before creating Bug Reports or Feature Request, please check if there aren't any related [issues](https://github.com/babelfish-for-postgresql/babelfish_extensions/issues).
+If you have found bugs or want to make suggestions, we are open to all kinds of contributions to improve the product. Before creating a Bug Report or Feature Request, please check for related [issues](https://github.com/babelfish-for-postgresql/babelfish_extensions/issues).


### PR DESCRIPTION
Signed-off-by: susanmdouglas <susandou@amazon.com>

### Description
Updates wording in getting_help.md; fixes broken link as well...
 
### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
