### PR TITLE
feat: Adding documentation and fixes to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -2,11 +2,6 @@ name: Babelfish for PostgreSQL Website Bug Report
 description: File a bug report for Babelfish Website
 title: "[Bug]: "
 labels: ["bug", "triage"]
-assignees:
-  - 3manuek
-  - xaviersierra
-  - gopinathpai
-  - nasbyj
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -3,36 +3,30 @@ description: File a bug report for Babelfish Website
 title: "[Bug]: "
 labels: ["bug", "triage"]
 assignees:
-  - amazon-auto
+  - 3manuek
+  - xaviersierra
+  - gopinathpai
+  - nasbyj
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out this bug report!
+        Thanks for taking the time to fill out this bug report.
   - type: input
     id: contact
     attributes:
       label: Contact Details
-      description: How can we get in touch with you if we need more info?
+      description: Please enter your mail address for contacting in the case of needing more information.
       placeholder: ex. email@example.com
     validations:
       required: false
   - type: textarea
     id: what-happened
     attributes:
-      label: What happened?
-      description: Also tell us, what did you expect to happen?
-      placeholder: Tell us what you see!
+      label: Describe the bug
+      description: Describe what was the expected behavior of the website. 
+      placeholder: Tell us what you see.
       value: "A bug happened!"
-    validations:
-      required: true
-  - type: dropdown
-    id: version
-    attributes:
-      label: Version
-      description: What version of our software are you running?
-      options:
-        - main (Default)
     validations:
       required: true
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -13,7 +13,7 @@ body:
       label: Describe the bug
       description: Describe the expected behavior of the website. 
       placeholder: Tell us what you see.
-      value: "Describe the bug that you've encountered and website behavior."
+      value: "Describe the expected behavior of the website."
     validations:
       required: true
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -12,21 +12,13 @@ body:
     attributes:
       value: |
         Thank you for taking the time to fill out this bug report.
-  - type: input
-    id: contact
-    attributes:
-      label: Contact Details
-      description: Please provide an email address where we can contact you for more information.
-      placeholder: ex. email@example.com
-    validations:
-      required: false
   - type: textarea
     id: what-happened
     attributes:
       label: Describe the bug
       description: Describe the expected behavior of the website. 
       placeholder: Tell us what you see.
-      value: "A bug happened!"
+      value: "Describe the bug that you've encountered and website behavior."
     validations:
       required: true
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -11,12 +11,12 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out this bug report.
+        Thank you for taking the time to fill out this bug report.
   - type: input
     id: contact
     attributes:
       label: Contact Details
-      description: Please enter your mail address for contacting in the case of needing more information.
+      description: Please provide an email address where we can contact you for more information.
       placeholder: ex. email@example.com
     validations:
       required: false
@@ -24,7 +24,7 @@ body:
     id: what-happened
     attributes:
       label: Describe the bug
-      description: Describe what was the expected behavior of the website. 
+      description: Describe the expected behavior of the website. 
       placeholder: Tell us what you see.
       value: "A bug happened!"
     validations:
@@ -33,7 +33,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://aws.github.io/code-of-conduct-faq)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://aws.github.io/code-of-conduct-faq).
       options:
-        - label: I agree to follow this project's Code of Conduct
+        - label: I agree to follow this project's Code of Conduct.
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Babelfish for PostgreSQL Website
-    url: https://github.community/
-    about: Please ask and answer questions here.
+    url: https://babelfishpg.org/
+    about: Please see or website for documentation and news.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: true
 contact_links:
   - name: Babelfish for PostgreSQL Website
     url: https://babelfishpg.org/
-    about: Please see or website for documentation and news.
+    about: Please see our website for documentation and news.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,5 +1,5 @@
 name: Babelfish for PostgreSQL Documentation
-description: Propose changes to Babelfish for PostgreSQL Documentation
+description: Propose changes to Babelfish for PostgreSQL documentation
 title: "[Documentation]: "
 labels: ["documentation", "untriaged"]
 assignees:
@@ -11,20 +11,20 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out this documentation improvement.
+        Thank you for taking the time to fill out this documentation improvement request.
   - type: input
     id: contact
     attributes:
       label: Contact Details
-      description: Please enter your mail address for contacting in the case of needing more information.
+      description: Please provide an email address where we can contact you for more information.
       placeholder: ex. email@example.com
     validations:
       required: false
   - type: textarea
     id: documentation-scope
     attributes:
-      label: What needs to be changed, updated or improve in the Babelfish Documentation?
-      description: Be explanatory, as detailed as you can. 
+      label: What needs to be changed, updated, or improved in the Babelfish documentation?
+      description: Please provide as much detail as possible. 
       placeholder: Tell us what you have in mind!
       value: "This is my feature request!"
     validations:
@@ -32,15 +32,15 @@ body:
   - type: textarea
     id: brief-desc-implementation
     attributes:
-      label: If want to provide us a more details about how to implement.
-      description: Share with us if you have more details about the implementation.
+      label: If possible, provide details about how to best implement this change.
+      description: Share implementation details for this improvement.
     validations:
       required: false 
   - type: dropdown
     id: version
     attributes:
       label: Version
-      description: Select the version of the targeted documentation.
+      description: Select the Babelfish documentation version to which the change applies.
       options:
         - BABEL_1_X_DEV (Default)
       required: true
@@ -54,7 +54,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://aws.github.io/code-of-conduct-faq)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://aws.github.io/code-of-conduct-faq).
       options:
-        - label: I agree to follow this project's Code of Conduct
+        - label: I agree to follow this project's Code of Conduct.
           required: true

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -2,11 +2,6 @@ name: Babelfish for PostgreSQL Documentation
 description: Propose changes to Babelfish for PostgreSQL documentation
 title: "[Documentation]: "
 labels: ["documentation", "untriaged"]
-assignees:
-  - gopinathpai
-  - nasbyj
-  - rcv-aws
-  - susanmdouglas-aws
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,17 +1,17 @@
-name: Babelfish for PostgreSQL Website Feature Request Form
-description: Propose an enhancement for Babelfish for PostgreSQL Website
-title: "[Enhancement]: "
-labels: ["enhancement", "untriaged"]
+name: Babelfish for PostgreSQL Documentation
+description: Propose changes to Babelfish for PostgreSQL Documentation
+title: "[Documentation]: "
+labels: ["documentation", "untriaged"]
 assignees:
-  - 3manuek
   - gopinathpai
-  - xaviersierra
   - nasbyj
+  - rcv-aws
+  - susanmdouglas-aws
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out this feature request.
+        Thanks for taking the time to fill out this documentation improvement.
   - type: input
     id: contact
     attributes:
@@ -21,10 +21,10 @@ body:
     validations:
       required: false
   - type: textarea
-    id: what-intends
+    id: documentation-scope
     attributes:
-      label: Describe what this feature intends to solve.
-      description: Be explanatory, as detailed as you can.
+      label: What needs to be changed, updated or improve in the Babelfish Documentation?
+      description: Be explanatory, as detailed as you can. 
       placeholder: Tell us what you have in mind!
       value: "This is my feature request!"
     validations:
@@ -36,6 +36,14 @@ body:
       description: Share with us if you have more details about the implementation.
     validations:
       required: false 
+  - type: dropdown
+    id: version
+    attributes:
+      label: Version
+      description: Select the version of the targeted documentation.
+      options:
+        - BABEL_1_X_DEV (Default)
+      required: true
   - type: textarea
     id: docs
     attributes:

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -11,15 +11,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for taking the time to fill out this documentation improvement request.
-  - type: input
-    id: contact
-    attributes:
-      label: Contact Details
-      description: Please provide an email address where we can contact you for more information.
-      placeholder: ex. email@example.com
-    validations:
-      required: false
+        Thanks for taking the time to fill out this documentation improvement request.
   - type: textarea
     id: documentation-scope
     attributes:
@@ -32,7 +24,7 @@ body:
   - type: textarea
     id: brief-desc-implementation
     attributes:
-      label: If possible, provide details about how to best implement this change.
+      label: Provide more details about how to best implement this change.
       description: Share implementation details for this improvement.
     validations:
       required: false 

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -2,11 +2,6 @@ name: Babelfish for PostgreSQL Website Feature Request Form
 description: Propose an enhancement for the Babelfish for PostgreSQL Website
 title: "[Enhancement]: "
 labels: ["enhancement", "untriaged"]
-assignees:
-  - 3manuek
-  - gopinathpai
-  - xaviersierra
-  - nasbyj
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -12,18 +12,10 @@ body:
     attributes:
       value: |
         Thank you for taking the time to fill out this feature request.
-  - type: input
-    id: contact
-    attributes:
-      label: Contact Details
-      description: Please provide an email address where we can contact you for more information.
-      placeholder: ex. email@example.com
-    validations:
-      required: false
   - type: textarea
     id: what-intends
     attributes:
-      label: Describe the enhancement, and how the change will improve the website.
+      label: Describe how this change will improve the Babelfish website.
       description: Provide as much detailed information as you can about the website improvement.
       placeholder: Tell us what you have in mind!
       value: "This is my feature request!"

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,5 +1,5 @@
 name: Babelfish for PostgreSQL Website Feature Request Form
-description: Propose an enhancement for Babelfish for PostgreSQL Website
+description: Propose an enhancement for the Babelfish for PostgreSQL Website
 title: "[Enhancement]: "
 labels: ["enhancement", "untriaged"]
 assignees:
@@ -11,20 +11,20 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out this feature request.
+        Thank you for taking the time to fill out this feature request.
   - type: input
     id: contact
     attributes:
       label: Contact Details
-      description: Please enter your mail address for contacting in the case of needing more information.
+      description: Please provide an email address where we can contact you for more information.
       placeholder: ex. email@example.com
     validations:
       required: false
   - type: textarea
     id: what-intends
     attributes:
-      label: Describe what this feature intends to solve.
-      description: Be explanatory, as detailed as you can.
+      label: Describe the enhancement, and how the change will improve the website.
+      description: Provide as much detailed information as you can about the website improvement.
       placeholder: Tell us what you have in mind!
       value: "This is my feature request!"
     validations:
@@ -32,21 +32,21 @@ body:
   - type: textarea
     id: brief-desc-implementation
     attributes:
-      label: If want to provide us a more details about how to implement.
-      description: Share with us if you have more details about the implementation.
+      label: Share implementation details for the website enhancement.
+      description: Share detailed information about the implementation.
     validations:
       required: false 
   - type: textarea
     id: docs
     attributes:
       label: Relevant documentation
-      description: Please attach relevant documentation.
+      description: Please attach any documentation relevant to the enhancement.
       render: shell
   - type: checkboxes
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://aws.github.io/code-of-conduct-faq)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://aws.github.io/code-of-conduct-faq).
       options:
-        - label: I agree to follow this project's Code of Conduct
+        - label: I agree to follow this project's Code of Conduct.
           required: true


### PR DESCRIPTION
Signed-off-by: 3manuek <emanuel@ongres.com>

### Description

- Added documentation issue template.
- Fixes on templates wording.
 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
