### PR TITLE
Reworked/worded _internals/software-architecture.md

### DIFF
--- a/_internals/software-architecture.md
+++ b/_internals/software-architecture.md
@@ -47,7 +47,7 @@ deployment mode in Babelfish.
 
 In `multi-db` mode, when you call the `USE` command to switch from one database to the other, you remain 
 connected to the same PostgreSQL database, but switch to a different schema. Understanding this relationship 
-will help you if you plan to query the same table using both protocols.
+may help you if you plan to query the same table using both protocols.
 
 To learn more about single and multi-database deployments, [see the documentation](/docs/installation/single-multiple),
 which deals with this topic in more detail.

--- a/_internals/software-architecture.md
+++ b/_internals/software-architecture.md
@@ -9,17 +9,17 @@ Babelfish uses [hooks](/docs/internals/postgresql-hooks) to implement Microsoft 
 from a PostgreSQL server. This allows the PostgreSQL server to speak more than one language, making
 the setup flexible and easy to manage.
 
-By default, Babelfish listens for connections on two TCP ports, in two dialects:
+A PostgreSQL database that is running Babelfish listens for connections on two (configurable) TCP 
+ports, in two dialects:
 
-- SQL Server dialect, clients connect to port 1433.
-- PostgreSQL dialect, clients connect to port 5432.
-
+- SQL Server dialect (TDS).
+- PostgreSQL dialect.
+ 
+Once the TDS handler has accepted and processed a request coming in on the TDS port,
+the request is passed on to a PostgreSQL backend. The backend parses the request using a 
+custom parser, modified to understand SQL Server dialect.
 
 <img src="/assets/images/babel_architecture.png" title="System architecture" width="800"/>
-
-Once the TDS handler has accepted and processed a request coming in on port 1433,
-the request is passed on to a standard PostgreSQL backend. The backend parses the request using a 
-custom parser, modified to understand SQL Server dialect.
 
 There are no significant changes to the PostgreSQL optimizer or the PostgreSQL executor.
 
@@ -57,7 +57,7 @@ which deals with this topic in more detail.
 
 Babelfish uses extensions to make PostgreSQL compatible with SQL Server:
 
-- `babelfishpg_common`: Microsoft SQL Server data types
+- `babelfishpg_common`: SQL Server data types
 - `babelfishpg_money`: Fixed precision numeric type
 - `babelfishpg_tds`: TDS protocol extension
 - `babelfishpg_tsql`: T-SQL extension
@@ -68,7 +68,7 @@ Here is a more detailed description of these extensions:
 
 Data types are often really similar but not necessarily 100% identical.
 Therefore, the Babelfish development team provides specific data types which
-mimic Microsoft SQL Server behavior. You will find an up-to-date list of unsupported 
+mimic SQL Server behavior. You will find an up-to-date list of unsupported 
 data types and other functionality on the [Babelfish compatibility page](usage/limitations-of-babelfish/).
 
 #### `babelfishpg_money`: Money data type

--- a/_internals/software-architecture.md
+++ b/_internals/software-architecture.md
@@ -34,7 +34,7 @@ out our section about [limitations and compatibility issues](/docs/usage/limitat
 
 PostgreSQL supports the following logical structure of objects:
 
-- Instance: a running PostgreSQL server
+- Instance: a running PostgreSQL server (the PostgreSQL community documentation calls this a cluster)
 - Database: what a user connects to
 - Schema: a logical grouping of tables and other objects inside a database
 - Table: where the data is stored

--- a/_internals/software-architecture.md
+++ b/_internals/software-architecture.md
@@ -5,77 +5,57 @@ nav_order: 1
 use_mermaid: true
 ---
 
-Babelfish implements Microsoft SQL Server behavior on top of PostgreSQL. To achieve this goal, a
-couple of areas had to be modified inside the PostgreSQL core. PostgreSQL does
-not offer this capability out-of-the-box, therefore add-ons had to be provided
-to make this happen.
+Babelfish uses [hooks](/docs/internals/postgresql-hooks) to implement Microsoft SQL Server behavior
+from a PostgreSQL server. This allows the PostgreSQL server to speak more than one language, making
+the setup flexible and easy to manage.
 
-The way Babelfish implements Microsoft SQL Server behavior is by using
-[hooks](/docs/internals/postgresql-hooks). The idea is to make database protocols &ldquo;pluggable&rdquo;,
-which means that PostgreSQL can present itself as a different database. In fact, it
-is even possible to speak more than a single protocol at the same time, making
-the setup more flexible and easy to handle.
-
-<img src="/assets/images/babel_architecture.png" title="System architecture" width="800"/>
-
-Once the TDS handler has accepted the request coming in on the default port 1433,
-and once it has processed it, it is passed on via pltds to a standard PostgreSQL backend.
-PostgreSQL will still be exposed to the client on port 5432 (default).
-
-To sum it up: default:
+By default, Babelfish listens for connections on two TCP ports, in two dialects:
 
 - SQL Server dialect, clients connect to port 1433.
 - PostgreSQL dialect, clients connect to port 5432.
 
-In other words, a Babelfish enabled database will listen for connections on two
-TCP ports instead of one. Administrators have to take that into account. The ports
-used can be configured using PostgreSQL parameters.
 
-How does that work? The TDS listener captures the requests coming
-from the client and sends them though a parser for the SQL dialect of Microsoft
-SQL Server.  The query will then be handled by a regular PostgreSQL
-backend. The optimizer and the executor will basically be the same.
+<img src="/assets/images/babel_architecture.png" title="System architecture" width="800"/>
 
-However, some changes had to be made to the PostgreSQL core to prepare for
-trigger processing, transaction handling and other aspects that are different in
-Microsoft SQL Server.  This means that the database server is not 100% identical
-to what one would expect from PostgreSQL.  Some behavior had to be changed to
-behave like Microsoft SQL Server.  Keep that in mind!
+Once the TDS handler has accepted and processed a request coming in on port 1433,
+the request is passed on to a standard PostgreSQL backend. The backend parses the request using a 
+custom parser, modified to understand SQL Server dialect.
 
-To find out more about what has to be changed and which challenges there are, check
+There are no significant changes to the PostgreSQL optimizer or the PostgreSQL executor.
+
+The PostgreSQL core that is distributed with Babelfish has been modified to prepare for trigger processing, 
+transaction handling, and other behaviors that are different in SQL Server. This means that the database 
+server is not 100% identical to a community distribution of PostgreSQL.  
+
+To find out more about unsupported SQL Server behaviors, check
 out our section about [limitations and compatibility issues](/docs/usage/limitations-of-babelfish).
 
 ### Databases vs. schemas
 
-PostgreSQL offers the following logical structure of objects:
+PostgreSQL supports the following logical structure of objects:
 
 - Instance: a running PostgreSQL server
-- Databases: what a user connects to
-- Schemas: a logical grouping of tables and other objects inside a database
-- Tables: where the data are really stored
+- Database: what a user connects to
+- Schema: a logical grouping of tables and other objects inside a database
+- Table: where the data is stored
 
-Microsoft SQL Server has the same layers.  There, the `USE` command
-allows us to switch between databases. Also, in contrast to PostgreSQL,
-one can query tables from another database and join tables from different databases.
-To enable cross-database joins, you can use the `multi-db` migration mode
-in Babelfish.  In that mode, databases in TDS connections (let's call them
-&ldquo;T-SQL databases&rdquo; for short) have been modelled as schemas in PostgreSQL.
+SQL Server supports the same objects.  
 
-In `multi-db` mode, if you are calling `USE` to switch from one
-database to the other, you actually remain connected to the same
-PostgreSQL database, but you will be working in different
-schemas. Understanding this fact is important to organize data
-properly and query the same tables using both protocols.
+In contrast to PostgreSQL, SQL Server allows you to query tables that reside in another database, 
+or join tables in different databases. To enable cross-database joins, you should use the `multi-db` 
+deployment mode in Babelfish.
 
-If you want to find out more about single- and multi-database
-setups [see the documentation](/docs/installation/single-multiple),
+In `multi-db` mode, when you call the `USE` command to switch from one database to the other, you remain 
+connected to the same PostgreSQL database, but switch to a different schema. Understanding this relationship 
+will help you if you plan to query the same table using both protocols.
+
+To learn more about single and multi-database deployments, [see the documentation](/docs/installation/single-multiple),
 which deals with this topic in more detail.
 
-### Extensions needed for Babelfish
 
-Making PostgreSQL compatible with Microsoft SQL Server requires some additional
-extensions which are provided by the Babelfish distribution. In this section, you
-will learn which ones are important and what their purpose is.
+### Babelfish extensions
+
+Babelfish uses extensions to make PostgreSQL compatible with SQL Server:
 
 - `babelfishpg_common`: Microsoft SQL Server data types
 - `babelfishpg_money`: Fixed precision numeric type
@@ -84,50 +64,25 @@ will learn which ones are important and what their purpose is.
 
 Here is a more detailed description of these extensions:
 
-#### `babelfishpg_common`: Microsoft SQL Server data types
+#### `babelfishpg_common`: SQL Server data types
 
 Data types are often really similar but not necessarily 100% identical.
 Therefore, the Babelfish development team provides specific data types which
-mimic Microsoft SQL Server behavior. Fortunately, there were only a handful of
-types which behave differently. Here is a complete list of these types:
+mimic Microsoft SQL Server behavior. You will find an up-to-date list of unsupported 
+data types and other functionality on the [Babelfish compatibility page](usage/limitations-of-babelfish/).
 
-- `sys.BBF_BINARY`: Data type for binary data.
-- `sys.BIT`: Converts 1 or 0 to `t` or `f`.
-- `sys.BPCHAR` and `sys.VARCHAR`: Microsoft SQL Server specific `varchar` implementation
-- `sys.DATETIME`: A simple data type for time and date. For more precision use
-  `DATETIME2`.
-- `sys.DATETIME2`: An extension for `DATETIME` with more
-  precision and functionality.
-- `sys.DATETIMEOFFSET`: Like `DATETIME2`, but with timezone awareness.
-- `sys.SMALLDATETIME`: Defines a date that is combined with a time of day. The time
-  is based on a 24-hour day, with seconds always zero (:00) and without
-  fractional seconds.
-- `sys.SQL_VARIANT`: Enables these database objects to support values of
-  other data types.
-- `sys.UNIQUEIDENTIFIER`: 16 byte GUID (e.g. `6F9619FF-8B86-D011-B42D-00C04FC964FF`)
+#### `babelfishpg_money`: Money data type
 
-#### `babelfishpg_money`: Fixed precision numeric type
-
-In addition to the core data types outlined in the previous section, there is
-one more data type which is packaged into a separate extension for licensing
-reasons: `fixeddecimal`.
-
-See the
-[documentation of the original software](https://github.com/2ndQuadrant/fixeddecimal/blob/master/README.md)
-for usage instructions and other information.
+The `babelfishpg_money` extension implements the money data type.
 
 #### `babelfishpg_tds`: TDS protocol extension
 
-This extension handles the TDS client-server protocol.  It has to be loaded
-at server startup time using `shared_preload_libraries`, so that it can start
-listening on the TDS port for incoming connections.
+This extension implements the TDS client-server protocol.  You need to modify the `shared_preload_libraries` 
+parameter (in the postgresql.conf file) to ensure that the extension is loaded
+at server startup time. 
 
 #### `babelfishpg_tsql`: T-SQL extension
 
-The purpose of this extension is to provide all code needed for T-SQL handling.
-Without it, writing stored procedure code is impossible.
+This extension provides the code needed for to handle T-SQL syntax.  It contains functions,
+[system views](/docs/internals/system-views) and other infrastructure required to implement SQL Server functionality.
 
-It contains a large number of functions, system views and other infrastructure
-needed to implement Microsoft SQL Server functionality.
-
-Babelfish provides [a variety of system views](/docs/internals/system-views).


### PR DESCRIPTION
### Description
Architecture page edits
 
### Issues Resolved
This PR replaces #126.  This page discusses the architectural differences between Babelfish and community PostgreSQL. 
 This patch fixes grammar and chattiness in the original document, and removes excessive exclamation points, questions, and company references.  Removes specific port values,  documents the purpose of each extension, removes the list of unsupported datatypes (that information is already in the Limitations documentation).

### Check List
- [x ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
