### PR TITLE
Highlighted SSMS OE limitation in a quote

### DIFF
--- a/_usage/command-line.md
+++ b/_usage/command-line.md
@@ -46,7 +46,11 @@ SSMS is one of the most commonly used clients to connect to Babelfish.
 
 In the following procedure, you connect to your Babelfish database by
 using SSMS. You can use the SSMS query editor to connect to a Babelfish database.
-Currently, you can not connect using the SSMS Object Explorer.
+
+
+>
+> _Currently, you **can not connect using the SSMS Object Explorer**._
+>
 
 #### Connecting with SSMS
 

--- a/_usage/command-line.md
+++ b/_usage/command-line.md
@@ -49,7 +49,7 @@ using SSMS. You can use the SSMS query editor to connect to a Babelfish database
 
 
 >
-> _Currently, you **can not connect using the SSMS Object Explorer**._
+> _You **can't currently connect using the SSMS Object Explorer**._
 >
 
 #### Connecting with SSMS


### PR DESCRIPTION
Signed-off-by: Emanuel Calvo <emanuel@ongres.com>

### Description

The "SSMS Object Explorer support limitation" sentence has been moved to a quote, considering that the original documentation does this emphasis. 
 
References:

- [Babelfish original documentation](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/babelfish-connect-sqlserver.html#babelfish-connect-SSMS)
- [Issue #55](https://github.com/babelfish-for-postgresql/babelfish_extensions/issues/55)


### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
