### PR TITLE
Bump version tag to BABEL_1_0_0

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -29,7 +29,7 @@ body:
       label: Version
       description: Select the Babelfish documentation version to which the change applies.
       options:
-        - BABEL_1_X_DEV (Default)
+        - BABEL_1_0_0 (Default)
       required: true
   - type: textarea
     id: docs

--- a/_data/repos.yml
+++ b/_data/repos.yml
@@ -16,7 +16,7 @@
     special_files:
       -
         title: Contributing
-        url: https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/BABEL_1_X_DEV/CONTRIBUTING.md
+        url: https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/BABEL_1_0_0/CONTRIBUTING.md
 
 -
     shortname: compass

--- a/_docs/index.md
+++ b/_docs/index.md
@@ -28,10 +28,10 @@ Babelfish for PostgreSQL intends to move forward on its integration into the Pos
 Component | Purpose
 :--- | :---
 [Babelfish Patch](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish) | Enables Babelfish hooks for PostgreSQL.
-[Babelfish TDS Extension](https://github.com/babelfish-for-postgresql/babelfish_extensions/tree/BABEL_1_X_DEV/contrib/babelfishpg_tds) | TDS - provides a secondary endpoint that speaks the TDS (SQL Server) network protocol.
-[Balbelfish Language Extension](https://github.com/babelfish-for-postgresql/babelfish_extensions/tree/BABEL_1_X_DEV/contrib/babelfishpg_tsql) | Provides a procedural language compatible with TSQL Uses ANTLR parser.
-[Babelfish Money Type](https://github.com/babelfish-for-postgresql/babelfish_extensions/tree/BABEL_1_X_DEV/contrib/babelfishpg_money) | Supports the money type in Microsoft SQL Server. This is a variation of the opensource fixeddecimal extension.
-[Babelfish Common](https://github.com/babelfish-for-postgresql/babelfish_extensions/tree/BABEL_1_X_DEV/contrib/babelfishpg_common) | Supports the various datatypes in Microsoft SQL Server.
+[Babelfish TDS Extension](https://github.com/babelfish-for-postgresql/babelfish_extensions/tree/BABEL_1_0_0/contrib/babelfishpg_tds) | TDS - provides a secondary endpoint that speaks the TDS (SQL Server) network protocol.
+[Balbelfish Language Extension](https://github.com/babelfish-for-postgresql/babelfish_extensions/tree/BABEL_1_0_0/contrib/babelfishpg_tsql) | Provides a procedural language compatible with TSQL Uses ANTLR parser.
+[Babelfish Money Type](https://github.com/babelfish-for-postgresql/babelfish_extensions/tree/BABEL_1_0_0/contrib/babelfishpg_money) | Supports the money type in Microsoft SQL Server. This is a variation of the opensource fixeddecimal extension.
+[Babelfish Common](https://github.com/babelfish-for-postgresql/babelfish_extensions/tree/BABEL_1_0_0/contrib/babelfishpg_common) | Supports the various datatypes in Microsoft SQL Server.
 
 
 
@@ -42,4 +42,4 @@ For specifics around the project, see the [FAQ](/docs/faq/).
 
 [Babelfish](https://babelfishpg.org/) is supported by Amazon Web Services. All components are available under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.html) and the [PostgreSQL License](https://www.postgresql.org/about/licence/) on [GitHub](https://github.com/babelfish-for-postgresql).
 
-The project welcomes GitHub issues, bug fixes, features, plugins, documentation---anything at all. To get involved, see [Contributing](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/BABEL_1_X_DEV/CONTRIBUTING.md) on the Babelfish for PostgreSQL website.
+The project welcomes GitHub issues, bug fixes, features, plugins, documentation---anything at all. To get involved, see [Contributing](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/BABEL_1_0_0/CONTRIBUTING.md) on the Babelfish for PostgreSQL website.

--- a/_installation/compiling-babelfish-from-source.md
+++ b/_installation/compiling-babelfish-from-source.md
@@ -136,7 +136,7 @@ make install    # Installs the PostgreSQL default extensions
 In order to build the extensions we would need to install some additional tools: 
 
 ##### Additional requied tools
-- [Antlr 4.9.2 Runtime](https://www.antlr.org/)
+- [Antlr 4.9.3 Runtime](https://www.antlr.org/)
 - [Open Java 8](https://openjdk.java.net/)
 - Unzip
 - [pkgconf](http://pkgconf.org/)
@@ -151,7 +151,7 @@ sudo apt install -y openjdk-8-jre unzip libutfcpp-dev cmake curl
 
 ##### Installing Antlr4 runtime
 
-> For Antlr4 4.9.2 Runtime, there are no available binaries for C++ in Ubuntu Focal, so it's necessary to compile it from source. Versions below 4.9 have not been fully tested yet. 
+> For Antlr4 4.9.3 Runtime, there are no available binaries for C++ in Ubuntu Focal, so it's necessary to compile it from source. Versions below 4.9 have not been fully tested yet. 
 
 To install the Antlr4 runtime, we need to have the Antlr4 .jar. Babelfish extensions source code includes 
 this .jar in the path `/contrib/babelfishpg_tsql/antlr/thirdparty/antlr`.
@@ -159,12 +159,12 @@ this .jar in the path `/contrib/babelfishpg_tsql/antlr/thirdparty/antlr`.
 Keeping this in mind, we can install Antlr4 runtime by running:
 
 ``` sh
-# Dowloads the compressed Antlr4 Runtime sources on /opt/antlr4-cpp-runtime-4.9.2-source.zip 
-sudo curl https://www.antlr.org/download/antlr4-cpp-runtime-4.9.2-source.zip \
-  --output /opt/antlr4-cpp-runtime-4.9.2-source.zip 
+# Dowloads the compressed Antlr4 Runtime sources on /opt/antlr4-cpp-runtime-4.9.3-source.zip 
+sudo curl https://www.antlr.org/download/antlr4-cpp-runtime-4.9.3-source.zip \
+  --output /opt/antlr4-cpp-runtime-4.9.3-source.zip 
 
 # Uncompress the source into /opt/antlr4
-sudo unzip -d /opt/antlr4 /opt/antlr4-cpp-runtime-4.9.2-source.zip
+sudo unzip -d /opt/antlr4 /opt/antlr4-cpp-runtime-4.9.3-source.zip
 
 sudo mkdir /opt/antlr4/build 
 cd /opt/antlr4/build
@@ -172,7 +172,7 @@ cd /opt/antlr4/build
 EXTENSIONS_SOURCE_CODE_PATH="<the patch in which you downloaded the Babelfish extensions source code>"
 
 # Generates the make files for the build
-sudo cmake .. -DANTLR_JAR_LOCATION="$EXTENSIONS_SOURCE_CODE_PATH/contrib/babelfishpg_tsql/antlr/thirdparty/antlr/antlr-4.9.2-complete.jar" \
+sudo cmake .. -DANTLR_JAR_LOCATION="$EXTENSIONS_SOURCE_CODE_PATH/contrib/babelfishpg_tsql/antlr/thirdparty/antlr/antlr-4.9.3-complete.jar" \
          -DCMAKE_INSTALL_PREFIX=/usr/local -DWITH_DEMO=True
 # Compiles and install
 sudo make
@@ -180,11 +180,11 @@ sudo make install
 ```
 
 Now that we have the antlr4 runtime installed, we need to copy the
-`libantlr4-runtime.so.4.9.2` library into the installed Babelfish for PostgreSQL
+`libantlr4-runtime.so.4.9.3` library into the installed Babelfish for PostgreSQL
 engine libs folder. We can do that by running the following command:
 
 ``` sh
-sudo cp /usr/local/lib/libantlr4-runtime.so.4.9.2 "$INSTALLATION_PATH/lib"
+sudo cp /usr/local/lib/libantlr4-runtime.so.4.9.3 "$INSTALLATION_PATH/lib"
 ```
 
 


### PR DESCRIPTION
Signed-off-by: Emanuel Calvo <emanuel@ongres.com>

### Description

This PR contains the necessary updates for the `BABEL_1_0_0` release (WIP fixes on tags):

- Updated tags across documentation and templates.
- Bumped ANLTR version to 4.9.3 according to [PR 66 in babelfish_extensions](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/66#pullrequestreview-868040254)

 
### Issues Resolved


### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
