### PR TITLE
Fixed broken link to Docker website in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This repo contains the source for the [babelfishpg.org](https://babelfishpg.org/
 
 You can build the Babelfish website on your local system with either Docker or Jekyll: 
 
-- After [installing Docker](https://jekyllrb.com/docs/installation/), you can build the site in a container with the command, `docker-compose up -d`. 
+- After [installing Docker](https://docs.docker.com/engine/install/), you can build the site in a container with the command, `docker-compose up -d`. 
 
 - After [installing Bundler](https://bundler.io/) and [Jekyll](https://jekyllrb.com/docs/installation/), invoke the following command to prepare the project files for the build:
 


### PR DESCRIPTION
Signed-off-by: susanmdouglas <susandou@amazon.com>

### Description
The link to the Docker website erroneously pointed to the Jekyll website... I've updated it with this commit.
 
### Issues Resolved
Fixed a bad link.

### Check List
- [ x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
