### PR TITLE
Updated links on Babelfish README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,13 @@
 
 ![Babelfish for PostgreSQL logo](assets/images/themed-logo.svg)
 
-- [babelfishpg.org Website](#babelfishpgorg-website)
-  - [Building the Website](#building-the-website)
-    -[Testing](#testing)
+- [babelfishpg.org Website](https://babelfishpg.org/)
+  - [Building the Website](#building-the-website-on-your-local-system)
     - [Link checker](#link-checker)
   - [Writing style guidelines](#writing-style-guidelines)
   - [Submitting a Pull Request](#submitting-a-pull-request)
-  - [Getting Help](#getting-help)
   - [Credits](#credits)   
-    - [Adding to the Partners Page](#adding-to-the-partners-page)
-  - [Copyright](#copyright)
-
-
+ 
 
 # Babelfishpg.org website
 


### PR DESCRIPTION
Updated links in navigation section of README.md file; some of the links at the top of the page are no longer available.

Signed-off-by: susanmdouglas <susandou@amazon.com>

### Description
Removed or replaced links at top of README.md file.
 
### Issues Resolved
Some of the links at the top of the page are no longer available.

### Check List
- [ x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
