### PR TITLE
This commit removes an extra square brace from the _includes/releases…

### DIFF
--- a/_includes/releases/babelfish-1.0.0.md
+++ b/_includes/releases/babelfish-1.0.0.md
@@ -1,7 +1,7 @@
 
 Babelfish Version: 1.0.0
 PostgreSQL Server Version: 13.4
-Minimum Compass Version: [1.0.0]](https://github.com/babelfish-for-postgresql/babelfish_compass/releases/tag/v1.0)
+Minimum Compass Version: [1.0.0](https://github.com/babelfish-for-postgresql/babelfish_compass/releases/tag/v1.0)
 Date: Oct 28, 2021
 
 


### PR DESCRIPTION
This commit removes an extra square brace from the _includes/releases/babelfish-1.0.0.md file.  It is a second commit of this fix; I missed the -s flag in the first commit, and Github would not forgive me.

Signed-off-by: susanmdouglas <susandou@amazon.com>

### Description
This commit removes an extra square brace from the _includes/releases/babelfish-1.0.0.md file.  It is a second commit of this fix; I missed the -s flag in the first commit, and Github would not forgive me.
 
### Issues Resolved
Fixes a broken link.

### Check List
- [x ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
