### PR TITLE
Updated configuration.md (parameter documentation)

### DIFF
--- a/_internals/configuration.md
+++ b/_internals/configuration.md
@@ -1,149 +1,303 @@
 ---
 layout: default
-title: Configuration variables
+title: Configuration parameters
 nav_order: 3
 ---
 
-## Configuring Babelfish
+## Babelfish configuration parameters
 
-Adjusting the behavior of Babelfish to your needs can be done by using
-a set of configuration variables. Babelfish provides a rich set of tweaks
-which will be described in this section.
+You can use Babelfish configuration parameters to adjust the behavior of Babelfish to best fit your needs. Some of these parameters should only be modified before cluster creation, while others should not be modified.
 
-The following configuration parameters are available:
+See the following descriptions for more information about each parameter.
 
-- `babelfishpg_tsql.allow_antlr_to_unsupported_grammar_for_testing`
-- `babelfishpg_tsql.ansi_defaults`
-- `babelfishpg_tsql.ansi_null_dflt_off`
-- `babelfishpg_tsql.ansi_null_dflt_on`
-- `babelfishpg_tsql.ansi_nulls`
-- `babelfishpg_tsql.ansi_padding`
-- `babelfishpg_tsql.ansi_warnings`
-- `babelfishpg_tsql.arithabort`
-- `babelfishpg_tsql.arithignore`
-- `babelfishpg_tsql.concat_null_yields_null`
-- `babelfishpg_tsql.cursor_close_on_commit`
-- `babelfishpg_tsql.database_name`
-- `babelfishpg_tsql.datefirst`
-- `babelfishpg_tsql.default_locale`
-- `babelfishpg_tsql.disable_batch_auto_commit`
-- `babelfishpg_tsql.disable_internal_savepoint`
-- `babelfishpg_tsql.disable_txn_in_triggers`
-- `babelfishpg_tsql.dump_antlr_query_graph`
-- `babelfishpg_tsql.enable_antlr_detailed_log`
-- `babelfishpg_tsql.enable_ownership_structure`
-- `babelfishpg_tsql.escape_hatch_compatibility_level`
-- `babelfishpg_tsql.escape_hatch_constraint_name_for_default`
-- `babelfishpg_tsql.escape_hatch_database_misc_options`
-- `babelfishpg_tsql.escape_hatch_for_replication`
-- `babelfishpg_tsql.escape_hatch_fulltext`
-- `babelfishpg_tsql.escape_hatch_index_clustering`
-- `babelfishpg_tsql.escape_hatch_index_columnstore`
-- `babelfishpg_tsql.escape_hatch_join_hints`
-- `babelfishpg_tsql.escape_hatch_language_non_english`
-- `babelfishpg_tsql.escape_hatch_login_hashed_password`
-- `babelfishpg_tsql.escape_hatch_login_misc_options`
-- `babelfishpg_tsql.escape_hatch_login_old_password`
-- `babelfishpg_tsql.escape_hatch_login_password_must_change`
-- `babelfishpg_tsql.escape_hatch_login_password_unlock`
-- `babelfishpg_tsql.escape_hatch_nocheck_add_constraint`
-- `babelfishpg_tsql.escape_hatch_nocheck_existing_constraint`
-- `babelfishpg_tsql.escape_hatch_query_hints`
-- `babelfishpg_tsql.escape_hatch_rowguidcol_column`
-- `babelfishpg_tsql.escape_hatch_schemabinding_function`
-- `babelfishpg_tsql.escape_hatch_schemabinding_procedure`
-- `babelfishpg_tsql.escape_hatch_schemabinding_trigger`
-- `babelfishpg_tsql.escape_hatch_schemabinding_view`
-- `babelfishpg_tsql.escape_hatch_session_settings`
-- `babelfishpg_tsql.escape_hatch_storage_on_partition`
-- `babelfishpg_tsql.escape_hatch_storage_options`
-- `babelfishpg_tsql.escape_hatch_table_hints`
-- `babelfishpg_tsql.escape_hatch_unique_constraint`
-- `babelfishpg_tsql.fmtonly`
-- `babelfishpg_tsql.implicit_transactions`
-- `babelfishpg_tsql.language`
-- `babelfishpg_tsql.migration_mode`
-- `babelfishpg_tsql.nocount`
-- `babelfishpg_tsql.noexec`
-- `babelfishpg_tsql.numeric_roundabort`
-- `babelfishpg_tsql.quoted_identifier`
-- `babelfishpg_tsql.rowcount`
-- `babelfishpg_tsql.server_collation_name`
-- `babelfishpg_tsql.showplan_all`
-- `babelfishpg_tsql.showplan_text`
-- `babelfishpg_tsql.showplan_xml`
-- `babelfishpg_tsql.sql_dialect`
-- `babelfishpg_tsql.trace_tree`
-- `babelfishpg_tsql.trace_exec_codes`
-- `babelfishpg_tsql.trace_exec_counts`
-- `babelfishpg_tsql.trace_exec_time`
-- `babelfishpg_tsql.textsize`
-- `babelfishpg_tsql.use_antlr`
-- `babelfishpg_tsql.version`
-- `babelfishpg_tsql.xact_abort`
-
-
-Here are the TDS related settings:
-
-- `babelfishpg_tds.default_server_name`
-- `babelfishpg_tds.listen_addresses`
-- `babelfishpg_tds.port`
-- `babelfishpg_tds.set_db_session_property`
-- `babelfishpg_tds.tds_debug_log_level`
-- `babelfishpg_tds.tds_default_numeric_precision`
-- `babelfishpg_tds.tds_default_numeric_scale`
-- `babelfishpg_tds.tds_default_packet_size`
-- `babelfishpg_tds.tds_default_protocol_version`
-- `babelfishpg_tds.tds_ssl_encrypt`
-- `babelfishpg_tds.tds_ssl_max_protocol_version`
-- `babelfishpg_tds.tds_ssl_min_protocol_version`
-- `babelfishpg_tds.trigger_fault_enabled`
-- `babelfishpg_tds.unix_socket_directories`
-- `babelfishpg_tds.unix_socket_group`
-- `babelfishpg_tds.unix_socket_permissions`
-
-Let us discuss these parameters in more detail.
-
-Escape hatches are described in more detail in the
-[section on limitations](/docs/usage/limitations-of-babelfish#babelfish-escape-hatches).
-
-### `babelfishpg_tsql.allow_antlr_to_unsupported_grammar_for_testing`
-
-Variable for internal testing - make `antlr` allow some unsupported grammar.
-The default value is `false`.
 
 ### `babelfishpg_tsql.ansi_defaults`
 
-When `ANSI_DEFAULTS` is enabled, it enables the following ISO settings:
-`ANSI_NULLS`, `ANSI_NULL_DFLT_ON`, `IMPLICIT_TRANSACTIONS`, `ANSI_PADDING`,
-`QUOTED_IDENTIFIER`, `ANSI_WARNINGS` and `CURSOR_CLOSE_ON_COMMIT`, but according to [the Microsoft documentation]
-(https://github.com/MicrosoftDocs/sql-docs/blob/live/docs/t-sql/statements/set-ansi-defaults-transact-sql.md)
-ODBC and OLE DB automatically set `ANSI_DEFAULTS` to `ON` when connecting.
-The driver and provider then set `CURSOR_CLOSE_ON_COMMIT` and
-`IMPLICIT_TRANSACTIONS` to `OFF`. So `CURSOR_CLOSE_ON_COMMIT` is actually `OFF` at
-connect time, but `ANSI_DEFAULTS` is `ON`.
-
-### `babelfishpg_tsql.ansi_null_dflt_off`
-
-Modifies the behavior of the session to override the default nullability of new
-columns when the ANSI `NULL` default option for the database is on.
-
-The setting `ON` is not allowed for option `ANSI_NULL_DFLT_OFF`.
-Please use `babelfishpg_tsql.escape_hatch_session_settings` to ignore this
-variable.
-
-### `babelfishpg_tsql.ansi_null_dflt_on`
-
-Modifies the behavior of the session to override default nullability of new columns
-when the ANSI `NULL` default option for the database is `false`.
-Setting to `OFF` is not allowed for the option `ANSI_NULL_DFLT_ON`. Please use
-`babelfishpg_tsql.escape_hatch_session_settings` to ignore resulting errors.
+When `ANSI_DEFAULTS` is turned on, it enables the following settings: `ANSI_NULLS`, `ANSI_NULL_DFLT_ON`, `IMPLICIT_TRANSACTIONS`, `ANSI_PADDING`, `QUOTED_IDENTIFIER`, `ANSI_WARNINGS` and `CURSOR_CLOSE_ON_COMMIT`. The driver and provider set `CURSOR_CLOSE_ON_COMMIT` and `IMPLICIT_TRANSACTIONS` to `OFF` (so `CURSOR_CLOSE_ON_COMMIT` is actually `OFF` at connect time, though `ANSI_DEFAULTS` is `ON`).
 
 
 ### `babelfishpg_tsql.ansi_nulls`
 
 Specifies ISO compliant behavior of the "equal" (`=`) and "not equal" (`<>`) comparison
 operators when they are used with `NULL` values.
+
+
+### `babelfishpg_tsql.concat_null_yields_null`
+
+If enabled, concatenating a `NULL` value produces a `NULL` result.
+
+
+### `babelfishpg_tsql.database_name`
+
+The predefined Babelfish database name. The default value is `babelfish_db`.
+
+
+### `babelfishpg_tsql.datefirst`
+
+Sets the first day of the week to a number from 1 through 7.
+
+
+### `babelfishpg_tsql.default_locale`
+
+The default locale to use when creating a new collation. The default value is `en_US`. You should not modify this value after a database is initialized. You must be a superuser to set this parameter.
+
+
+### `babelfishpg_tsql.disable_batch_auto_commit`
+
+This parameter disables auto commit inside procedures. The default value is `false`.
+
+
+### `babelfishpg_tsql.disable_txn_in_triggers`
+
+This parameter disables transactions in triggers. The default value is `false`.
+TSQL triggers terminate if there is no transaction active at the end.
+
+
+### `babelfishpg_tsql.dump_antlr_query_graph`
+
+This parameter instructs the server to dump the query graph parsed by ANTLR parser to local disk. The path used is
+`/tmp/antlr.dot`.
+
+
+### `babelfishpg_tsql.enable_antlr_detailed_log`
+
+This parameter enables detailed ANTLR parser logging.
+
+
+### `babelfishpg_tsql.fmtonly`
+
+This parameter controls SQL Server compatibility related to the `FMTONLY` option.
+
+
+### `babelfishpg_tsql.implicit_transactions`
+
+This parameter enables implicit transactions.
+If no transaction is running, the server will start an implicit transaction
+for qualified commands when the `implicit_transactions` parameter is set to
+on.
+
+
+### `babelfishpg_tsql.language`
+
+This parameter controls the T-SQL compatibility language option.
+
+
+### `babelfishpg_tsql.migration_mode`
+
+This parameter specifies if multiple T-SQL databases are supported. Valid options are:
+`single-db`, `multi-db` and `NULL` (same as `single-db`).
+For more information, see the [discussion of single-DB versus multiple-DB setup](docs/installation/single-multiple).
+
+This parameter should not be changed after the database is initialized.
+
+
+### `babelfishpg_tsql.nocount`
+
+This parameter controls the T-SQL compatibility `NOCOUNT` option.
+
+
+### `babelfishpg_tsql.noexec`
+
+This parameter controls the SQL Server compatibility `NOEXEC` option.
+
+
+### `babelfishpg_tsql.quoted_identifier`
+
+This parameter instructs Babelfish to interpret double-quoted strings as quoted identifiers.
+
+
+### `babelfishpg_tsql.rowcount`
+
+This parameter instructs Babelfish to stop processing the query after the
+specified number of rows are returned.
+
+
+### `babelfishpg_tsql.server_collation_name`
+
+This parameter specifies the name of the default [server collation](https://babelfishpg.org/docs/usage/locales/). The default value is
+`sql_latin1_general_cp1_ci_as`. You should not modify this setting after initializing the database.
+
+
+### `babelfishpg_tsql.showplan_all`
+
+This parameter controls the SQL Server compatibility `SHOWPLAN_ALL` option.
+
+
+### `babelfishpg_tsql.showplan_text`
+
+This parameter controls the SQL Server compatibility `SHOWPLAN_TEXT` option.
+
+
+### `babelfishpg_tsql.showplan_xml`
+
+This parameter controls the SQL Server compatibility `SHOWPLAN_XML` option.
+
+
+### `babelfishpg_tsql.trace_tree`
+
+This parameter instructs Babelfish to dump the compiled parse tree prior to code generation.
+
+
+### `babelfishpg_tsql.trace_exec_codes`
+
+This parameter instructs Babelfish to trace the execution code of iterative executors.
+
+
+### `babelfishpg_tsql.trace_exec_counts`
+
+This parameter instructs Babelfish to trace the execution count of iterative executors.
+
+
+### `babelfishpg_tsql.trace_exec_time`
+
+This parameter instructs Babelfish to trace the execution time of iterative executors.
+
+
+### `babelfishpg_tsql.textsize`
+
+This parameter sets the `TEXTSIZE`.
+
+
+### `babelfishpg_tsql.use_antlr`
+
+This parameter is now obsolete; there is no way to switch parsers, both yacc and antlr parsers are required.
+
+
+### `babelfishpg_tsql.version`
+
+This parameter sets the output of the `@@VERSION` function.
+
+
+### `babelfishpg_tsql.xact_abort`
+
+This parameter instructs Babelfish how to control transactional behavior when an error happens.
+
+
+### `babelfishpg_tds.default_server_name`
+
+This parameter specifies the predefined Babelfish default server name. The default value is Microsoft SQL Server.
+
+
+### `babelfishpg_tds.listen_addresses`
+
+This parameter sets the host name or IP address(es) for TDS to listen on.
+
+
+### `babelfishpg_tds.port`
+
+This parameter specifies the port to use for the TDS protocol (not standard PostgreSQL). Accepted values are from 1-65535; the default is 1433.
+
+
+### `babelfishpg_tds.set_db_session_property`
+
+This parameter specifies the database session property used for TDS connections. This means that
+`babelfishpg_tsql.database_name` is set during the login process. An error will
+occur if the `database_name` is not set.
+
+
+### `babelfishpg_tds.tds_debug_log_level`
+
+This parameter specifies the debug level for TDS. Accepted values are 0, 1, 2, 3; a setting of 0 will turn off logging. The default is 1.
+
+
+### `babelfishpg_tds.tds_default_numeric_precision`
+
+This parameter specifies the default precision of numeric type to be sent in the TDS column metadata if the engine does not specify one.
+Accepted values are from 1 to 38; the default value is 8.
+
+
+### `babelfishpg_tds.tds_default_numeric_scale`
+
+This parameter specifies the default scale of numeric type to be sent in the TDS column metadata if the engine does not specify one. Accepted values are from 0 to 38; the default value is 8.
+
+
+### `babelfishpg_tds.tds_default_packet_size`
+
+This parameter specifies the default packet size for all the clients being connected. Accepted values range from 512 to 32767; the default value is 4096.
+
+
+### `babelfishpg_tds.tds_default_protocol_version`
+
+This parameter specifies the default TDS protocol version for all the clients being connected. The accepted values are:
+
+- TDSv7.0
+- TDSv7.1
+- TDSv7.1.1
+- TDSv7.2
+- TDSv7.3A
+- TDSv7.3B 
+- TDSv7.4 
+- DEFAULT
+
+
+### `babelfishpg_tds.tds_ssl_encrypt`
+
+This parameter specifies the SSL encryption used by Babelfish. The default value is `false`.
+
+
+### `babelfishpg_tds.tds_ssl_max_protocol_version`
+
+Sets the maximum SSL/TLS protocol version to use for the TDS session. The default value is 'TLSv1.2'; accepted values are:
+
+- TLSv1
+- TLSv1.1
+- TLSv1.2
+
+
+### `babelfishpg_tds.tds_ssl_min_protocol_version`
+
+Sets the maximum SSL/TLS protocol version to use for the TDS session. The default value is 'TLSv1'; accepted values are:
+
+- TLSv1
+- TLSv1.1
+- TLSv1.2
+
+
+### `babelfishpg_tds.trigger_fault_enabled`
+
+This parameter controls fault injection triggers.
+
+
+### `babelfishpg_tds.unix_socket_directories`
+
+The UNIX socket directory. The default is /tmp.
+
+
+### `babelfishpg_tds.unix_socket_group`
+
+This parameter controls the UNIX socket group setting.
+
+
+### `babelfishpg_tds.unix_socket_permissions`
+
+This parameter controls UNIX socket permissions. The default is 0700.
+
+
+
+## Parameters that should not be modified
+
+You may come across these parameters in the source code, but you shouldn't change them:
+
+### `babelfishpg_tsql.allow_antlr_to_unsupported_grammar_for_testing`
+
+This parameter is used for internal testing, making `antlr` allow unsupported grammar.
+The default value is `false`.
+
+### `babelfishpg_tsql.ansi_null_dflt_off`
+
+This parameter modifies the behavior of the session to override the default nullability of new
+columns when the ANSI `NULL` default option for the database is on.
+
+The setting `ON` is not allowed for option `ANSI_NULL_DFLT_OFF`.
+Please use `babelfishpg_tsql.escape_hatch_session_settings` to ignore this
+parameter.
+
+### `babelfishpg_tsql.ansi_null_dflt_on`
+
+This parameter modifies the behavior of the session to override default nullability of new columns
+when the ANSI `NULL` default option for the database is `false`.
+Setting to `OFF` is not allowed for the option `ANSI_NULL_DFLT_ON`. Please use
+`babelfishpg_tsql.escape_hatch_session_settings` to ignore resulting errors.
 
 
 ### `babelfishpg_tsql.ansi_padding`
@@ -170,414 +324,36 @@ The setting `ON` is not allowed for this option. Please use
 `babelfishpg_tsql.escape_hatch_session_settings` to ignore errors.
 
 
-### `babelfishpg_tsql.concat_null_yields_null`
-
-If enabled, concatenating a `NULL` value produces a `NULL` result.
-
-
 ### `babelfishpg_tsql.cursor_close_on_commit`
 
 The setting `ON` is not allowed for this option. Please use
 `babelfishpg_tsql.escape_hatch_session_settings` to ignore errors.
 
 
-### `babelfishpg_tsql.database_name`
-
-Predefined Babelfish database name. The default value is `babelfish_db`.
-
-
-### `babelfishpg_tsql.datefirst`
-
-Sets the first day of the week to a number from 1 through 7.
-
-
-### `babelfishpg_tsql.default_locale`
-
-The default locale to use when creating a new collation. The default value is
-`en_US`. Only superusers can set this variable.
-
-
-### `babelfishpg_tsql.disable_batch_auto_commit`
-
-Disable auto commit inside procedures. The default value is `false`.
-
-
 ### `babelfishpg_tsql.disable_internal_savepoint`
 
-Disable internal savepoints. The default value is `false`.
-What is the purpose of this variable? It controls whether a savepoint is created to
-handle undo if a command fails. Savepoints are not started for batch commands, as
-error handling must be taken care of at the statement level.
-
+This parameter disables internal savepoints. The default value is `false`.
 This setting is for Babelfish development only and should not be used by end
 users.
 
 
-### `babelfishpg_tsql.disable_txn_in_triggers`
-
-Disable transactions in triggers. The default value is `false`.
-TSQL triggers terminate if there is no transaction active at the end.
-
-
-### `babelfishpg_tsql.dump_antlr_query_graph`
-
-Dump query graph parsed by ANTLR parser to local disk. The path used is
-`/tmp/antlr.dot`.
-
-
-### `babelfishpg_tsql.enable_antlr_detailed_log`
-
-Enable detailed ATNLR parser logging.
-
-
 ### `babelfishpg_tsql.enable_ownership_structure`
 
-Enable Babelfish ownership structure.  This flag is for Babelfish development
+This parameter enables Babelfish ownership structure.  This flag is for Babelfish development
 and should not be used by end users.
-
-
-### `babelfishpg_tsql.escape_hatch_compatibility_level`
-
-Suppresses the error when trying to set the compatibility level.
-
-
-### `babelfishpg_tsql.escape_hatch_constraint_name_for_default`
-
-Escape hatch for `DEFAULT` option in `ALTER TABLE ADD` constraint.
-
-
-### `babelfishpg_tsql.escape_hatch_database_misc_options`
-
-Escape hatch for misc options in `CREATE/ALTER DATABASE`.
-
-
-### `babelfishpg_tsql.escape_hatch_for_replication`
-
-Escape hatch for `[NOT] FOR REPLICATION` option.
-
-
-### `babelfishpg_tsql.escape_hatch_fulltext`
-
-Escape hatch for fulltext search.
-
-
-### `babelfishpg_tsql.escape_hatch_index_clustering`
-
-Escape hatch for `CLUSTERED` option in `CREATE INDEX` and constraints.
-
-
-### `babelfishpg_tsql.escape_hatch_index_columnstore`
-
-Escape hatch for `COLUMNSTORE` option in `CREATE INDEX`.
-
-
-### `babelfishpg_tsql.escape_hatch_join_hints`
-
-Escape hatch for join hints.
-
-
-### `babelfishpg_tsql.escape_hatch_language_non_english`
-
-Escape hatch for non-english language.
-
-
-### `babelfishpg_tsql.escape_hatch_login_hashed_password`
-
-Escape hatch for login hashed passwords.
-
-
-### `babelfishpg_tsql.escape_hatch_login_misc_options`
-
-Escape hatch for login miscellaneous options.
-
-
-### `babelfishpg_tsql.escape_hatch_login_old_password`
-
-Escape hatch for old login passwords.
-
-
-### `babelfishpg_tsql.escape_hatch_login_password_must_change`
-
-Escape hatch for login passwords `must_change` option.
-
-
-### `babelfishpg_tsql.escape_hatch_login_password_unlock`
-
-Escape hatch for login passwords unlock option.
-
-
-### `babelfishpg_tsql.escape_hatch_nocheck_add_constraint`
-
-Escape hatch for `WITH [NO]CHECK` option in `ALTER TABLE ADD`.
-
-
-### `babelfishpg_tsql.escape_hatch_nocheck_existing_constraint`
-
-Escape hatch for `WITH [NO]CHECK` option in `ALTER TABLE` on existing
-constraint.
-
-
-### `babelfishpg_tsql.escape_hatch_query_hints`
-
-Escape hatch for query hints.
-
-
-### `babelfishpg_tsql.escape_hatch_rowguidcol_column`
-
-Escape hatch for `ROWGUIDCOL` option.
-
-
-### `babelfishpg_tsql.escape_hatch_schemabinding_function`
-
-Escape hatch for `SCHEMABINDING` option in `CREATE FUNCTION`.
-
-
-### `babelfishpg_tsql.escape_hatch_schemabinding_procedure`
-
-Escape hatch for `SCHEMABINDING` option in `CREATE PROCEDURE`.
-
-
-### `babelfishpg_tsql.escape_hatch_schemabinding_trigger`
-
-Escape hatch for `SCHEMABINDING` option in `CREATE TRIGGER`.
-
-
-### `babelfishpg_tsql.escape_hatch_schemabinding_view`
-
-Escape hatch for `SCHEMABINDING` option in `CREATE VIEW`.
-
-
-### `babelfishpg_tsql.escape_hatch_session_settings`
-
-Escape hatch for session settings.
-
-
-### `babelfishpg_tsql.escape_hatch_storage_on_partition`
-
-Escape hatch for `storage_on_partition` option in
-`CREATE/ALTER TABLE` and `CREATE INDEX`.
-
-
-### `babelfishpg_tsql.escape_hatch_storage_options`
-
-Escape hatch for storage options option in `CREATE/ALTER TABLE/INDEX`.
-
-
-### `babelfishpg_tsql.escape_hatch_table_hints`
-
-Escape hatch for table hints.
-
-
-### `babelfishpg_tsql.escape_hatch_unique_constraint`
-
-Escape hatch for unique constraints.
-
-
-### `babelfishpg_tsql.fmtonly`
-
-SQL Server compatibility `FMTONLY` option.
-
-
-### `babelfishpg_tsql.implicit_transactions`
-
-Enable implicit transactions.
-If no transaction is running, start an implicit transaction
-for qualified commands when `implicit_transactions` config
-option is on.
-
-
-### `babelfishpg_tsql.language`
-
-T-SQL compatibility language option.
-
-
-### `babelfishpg_tsql.migration_mode`
-
-Defines if multiple T-SQL databases are supported. Valid options are:
-`single-db`, `multi-db` and `NULL` (same as `single-db`).
-See the [discussion of single-DB versus multiple-DB setup](docs/installation/single-multiple).
-
-
-### `babelfishpg_tsql.nocount`
-
-T-SQL compatibility `NOCOUNT` option.
-
-
-### `babelfishpg_tsql.noexec`
-
-SQL Server compatibility `NOEXEC` option.
 
 
 ### `babelfishpg_tsql.numeric_roundabort`
 
-Ends a query when an overflow or division-by-zero error occurs
+This parameter ends a query when an overflow or division-by-zero error occurs
 during query execution.
 The setting `ON` is not allowed for this option.
 
 
-### `babelfishpg_tsql.quoted_identifier`
-
-Interpret double-quoted strings as quoted identifiers.
-
-
-### `babelfishpg_tsql.rowcount`
-
-Causes the DB engine to stop processing the query after the
-specified number of rows are returned.
-
-
-### `babelfishpg_tsql.server_collation_name`
-
-Name of the default server collation. The default value is
-`sql_latin1_general_cp1_ci_as`.
-
-
-### `babelfishpg_tsql.showplan_all`
-
-SQL Server compatibility `SHOWPLAN_ALL` option.
-
-
-### `babelfishpg_tsql.showplan_text`
-
-SQL Server compatibility `SHOWPLAN_TEXT` option.
-
-
-### `babelfishpg_tsql.showplan_xml`
-
-SQL Server compatibility `SHOWPLAN_XML` option.
-
-
 ### `babelfishpg_tsql.sql_dialect`
 
-Sets the dialect for SQL commands. Valid options are `postgres`, `tsql` and
-`pg`.  This parameter is set by Babelfish, and you should never change it in
+This parameter sets the dialect for SQL commands. Valid options are `postgres`, `tsql` and
+`pg`.  This parameter is set by Babelfish; you should not change it during
 a database session.
 
 
-### `babelfishpg_tsql.trace_tree`
-
-Dump compiled parse tree prior to code generation.
-
-
-### `babelfishpg_tsql.trace_exec_codes`
-
-Trace execution code of iterative executor.
-
-
-### `babelfishpg_tsql.trace_exec_counts`
-
-Trace execution count of each code for iterative executor.
-
-
-### `babelfishpg_tsql.trace_exec_time`
-
-Trace execution time of each code for iterative executor.
-
-
-### `babelfishpg_tsql.textsize`
-
-Set `TEXTSIZE`.
-
-
-### `babelfishpg_tsql.use_antlr`
-
-This parameter is now obsolete, and will be removed in a future release.
-There is no way to switch parsers, both yacc and antlr parsers are required.
-
-For more information see [Issue #47](https://github.com/babelfish-for-postgresql/babelfish_extensions/issues/47#issuecomment-994107040).
-
-The default value is `true`.
-
-
-### `babelfishpg_tsql.version`
-
-Sets the output of the `@@VERSION` variable.
-
-
-### `babelfishpg_tsql.xact_abort`
-
-Control transactional behavior when an error happens.
-
-
-### `babelfishpg_tds.default_server_name`
-
-Predefined Babelfish default server name.
-
-
-### `babelfishpg_tds.listen_addresses`
-
-Sets the host name or IP address(es) for TDS to listen on.
-
-
-### `babelfishpg_tds.port`
-
-The port to use for the TDS protocol (not standard PostgreSQL).
-
-### `babelfishpg_tds.set_db_session_property`
-
-Set database session property on TDS connections. What it means is that
-`babelfishpg_tsql.database_name` is set during the login process. An error will
-happen if the `database_name` is not set.
-
-
-### `babelfishpg_tds.tds_debug_log_level`
-
-Set the debug level for TDS.
-
-
-### `babelfishpg_tds.tds_default_numeric_precision`
-
-Sets the default precision of numeric type to be sent in
-the TDS column metadata if the engine does not specify one.
-The default value is 38.
-
-
-### `babelfishpg_tds.tds_default_numeric_scale`
-
-Sets the default scale of numeric type to be sent in
-the TDS column metadata if the engine does not specify one.
-
-
-### `babelfishpg_tds.tds_default_packet_size`
-
-Sets the default packet size for all the clients being connected.
-
-
-### `babelfishpg_tds.tds_default_protocol_version`
-
-Sets a default TDS protocol version for all the clients being connected.
-
-
-### `babelfishpg_tds.tds_ssl_encrypt`
-
-Sets the SSL Encryption option. The default value is `false`.
-
-
-### `babelfishpg_tds.tds_ssl_max_protocol_version`
-
-Sets the maximum SSL/TLS protocol version to use for the TDS session.
-
-
-### `babelfishpg_tds.tds_ssl_min_protocol_version`
-
-Sets the maximum SSL/TLS protocol version to use for the TDS session.
-
-
-### `babelfishpg_tds.trigger_fault_enabled`
-
-Enable fault injection triggers.
-
-
-### `babelfishpg_tds.unix_socket_directories`
-
-The UNIX socket directory.
-
-
-### `babelfishpg_tds.unix_socket_group`
-
-The UNIX socket group.
-
-
-### `babelfishpg_tds.unix_socket_permissions`
-
-UNIX socket permissions.


### PR DESCRIPTION
Updated _internals/configuration.md to separate parameters into lists of parameters that can be modified and parameters that should not.  Also added information about default values and permissible parameter values.

Signed-off-by: susanmdouglas <susandou@amazon.com>

### Description
Updated _internals/configuration.md to separate parameters into lists of parameters that can be modified and parameters that should not.  Also added information about default values and permissible parameter values.
 
### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
