### PR TITLE
Enable descending order for versions list on the navigation sidebar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -120,6 +120,7 @@ just_the_docs:
     versions:
       name: Releases
       nav_fold: true
+      order: desc
 
 # Enable or disable the site search
 # Supports true (default) or false

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -57,6 +57,13 @@
 
   {%- assign pages_list = sorted_number_ordered_pages | concat: sorted_string_ordered_pages -%}
 
+  {%- comment -%}
+    Use descending ordering when explicitly requested
+  {%- endcomment -%}
+  {%- if include.order == "desc" -%}
+    {%- assign pages_list = pages_list | reverse -%}
+  {%- endif -%}
+
   {%- for node in pages_list -%}
     {%- if node.parent == nil -%}
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -81,7 +81,7 @@ layout: table_wrappers
                         <a href="#" class="nav-list-expander"><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>
                         {%- endif -%}
                         <div class="nav-category">{{ collection_value.name }}</div>
-                        {% include nav.html pages=collection key=collection_key %}
+                        {% include nav.html pages=collection key=collection_key order=collection_value.order %}
                       </li>
                     </ul>
                   {% else %}


### PR DESCRIPTION
Signed-off-by: ldgarcia <lgarcia@ongres.com>

### Description
Enable descending order for versions list on the navigation sidebar
 
### Issues Resolved
#205 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
