### PR TITLE
DO NOT MERGE until 2.1.0 - Documentation updates

### DIFF
--- a/_usage/locales.md
+++ b/_usage/locales.md
@@ -183,6 +183,8 @@ Babelfish collations.
 
 ### Using CHARINDEX() with a non-deterministic collation
 
+Note: the following limitation applies only to Babelfish version 1.x.x.  This issue has been resolved in version 2.1.0.
+
 `CHARINDEX()` cannot currently be used when the applicable collation is non-deterministic. Babelfish (by default) uses a non-deterministic case-insensitive collation, so you may encounter a run-time error saying "nondeterministic collations are not supported for substring searches". Until this is resolved, this issue can be worked around in two ways:
 
 - You can explicitly convert the expression to a case-sensitive collation and case-fold both arguments by applying LOWER() or UPPER(). For example: 


### PR DESCRIPTION
This PR contains the doc updates for Babelfish version 2.1.0.

Signed-off-by: susanmdouglas <susandou@amazon.com>

### Description
This commit includes doc updates for Babelfish version 2.1.0, including:
Updated _usage/locales.md to note that CHARINDEX limitation only applied to version 1.x and has been resolved in 2.x.
 
### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
