### PR TITLE
Fixes for 2.1.0 blog post and release notes

### DIFF
--- a/_includes/releases/babelfish-2.1.0.md
+++ b/_includes/releases/babelfish-2.1.0.md
@@ -20,6 +20,8 @@ Babelfish does not support an upgrade path to version 2.1.0 from Babelfish 1.x.x
 
 This version of Babelfish adds support for the following features:
 
+- Backported the fix from the PostgreSQL 14.4 release that [reverts changes to CONCURRENTLY](https://github.com/postgres/postgres/commit/e28bb885196916b0a3d898ae4f2be0e38108d81b) that speed up Xmin advance to prevent Index Corruption with the CREATE INDEX CONCURRENTLY / REINDEX CONCURRENTLY commands.
+
 - Support for functions: `IS_MEMBER()`, `IS_ROLEMEMBER()`, `HAS_PERMS_BY_NAME()`.
 
 - Support for the following catalogs: 

--- a/_posts/2022-07-06-babelfish-release.md
+++ b/_posts/2022-07-06-babelfish-release.md
@@ -11,7 +11,7 @@ categories:
 
 We’re excited to announce Babelfish 2.1.0, which makes it easier than ever to adopt Babelfish.  Our users have asked us to make Babelfish easier to use, and we’ve responded with a feature-packed release.  After installing 2.1.0, you can browse database tables and column types with SQL Server Management Studio (SSMS).  This release also adds support for creating roles on the TDS port with the CREATE ROLE command, and improves cross-database reference support for queries.
 
-We’re happy to announce that Babelfish delivers on these user requests, as well as others. You can see the full list of improvements in the [release notes](https://babelfishpg.org/docs/versions/babelfish-1-2-0.html).  As always, build directions for Babelfish and its prerequisites, along with Babelfish source distributions for 2.1.0 can be found in the [babelfish-for-postgresql repository](https://github.com/babelfish-for-postgresql/babelfish-for-postgresql/releases/tag/BABEL_2_1_0__PG_14_3).
+We’re happy to announce that Babelfish delivers on these user requests, as well as others. You can see the full list of improvements in the [release notes](https://babelfishpg.org/docs/versions/babelfish-2-1-0.html).  As always, build directions for Babelfish and its prerequisites, along with Babelfish source distributions for 2.1.0 can be found in the [babelfish-for-postgresql repository](https://github.com/babelfish-for-postgresql/babelfish-for-postgresql/releases/tag/BABEL_2_1_0__PG_14_3).
 
 We hope you relish the benefits and improved usability of the new Babelfish 2.1.0!
 


### PR DESCRIPTION
I've updated _posts/2022-07-06-babelfish-release.md to fix a broken link; the link was previously pointing to release notes for a different version.  I've also added a note to the release notes for 2.1.0  that this release also backported the fix from the PostgreSQL 14.4 community release that reverts changes to CONCURRENTLY.

Signed-off-by: susanmdouglas <susandou@amazon.com>

### Description
I've updated _posts/2022-07-06-babelfish-release.md to fix a broken link; the link was previously pointing to release notes for a different version.  I've also added a note to the release notes for 2.1.0  that this release also backported the fix from the PostgreSQL 14.4 community release that reverts changes to CONCURRENTLY.

### Issues Resolved
I've updated _posts/2022-07-06-babelfish-release.md to fix a broken link; the link was previously pointing to release notes for a different version.  I've also added a note to the release notes for 2.1.0  that this release also backported the fix from the PostgreSQL 14.4 community release that reverts changes to CONCURRENTLY.

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
