### PR TITLE
Remove mention of backpatching for CONCURRENTLY issue from release notes

### DIFF
--- a/_includes/releases/babelfish-2.1.0.md
+++ b/_includes/releases/babelfish-2.1.0.md
@@ -5,7 +5,7 @@
   - [BABEL_2_1_0__PG_14_3.tar.gz](https://github.com/babelfish-for-postgresql/babelfish-for-postgresql/releases/download/BABEL_2_1_0__PG_14_3/BABEL_2_1_0__PG_14_3.tar.gz)
 - Babelfish Compass
   - [Download](https://github.com/babelfish-for-postgresql/babelfish_compass/releases)
-- Date: June 9, 2022
+- Date: July 7, 2022
 
 ## Overview
 
@@ -19,8 +19,6 @@ Babelfish does not support an upgrade path to version 2.1.0 from Babelfish 1.x.x
 ## Changes
 
 This version of Babelfish adds support for the following features:
-
-- Backported the fix from the PostgreSQL 14.4 release that [reverts changes to CONCURRENTLY](https://github.com/postgres/postgres/commit/e28bb885196916b0a3d898ae4f2be0e38108d81b) that speed up Xmin advance to prevent Index Corruption with the CREATE INDEX CONCURRENTLY / REINDEX CONCURRENTLY commands.
 
 - Support for functions: `IS_MEMBER()`, `IS_ROLEMEMBER()`, `HAS_PERMS_BY_NAME()`.
 
@@ -36,7 +34,6 @@ This version of Babelfish adds support for the following features:
 
 |sp_sproc_columns|sp_sproc_columns_100||
 |sp_helprole|sp_helprolemember|
-
 
 - Cross-DB references outside the current database, with a 3-part object name, for SELECT,SELECT..INTO, INSERT, UPDATE, DELETE
 CREATE ROLE (AUTHORIZATION clause not supported), DROP ROLE, ALTER ROLE.


### PR DESCRIPTION
I've updated the release notes for 2.1.0 (_includes/releases/babelfish-2.1.0.md) to remove mention of the backpatching of the CONCURRENTLY problem from the community, and updated the release date. We may or may not need to merge this change, but I'd like to have it on hand in case we need it.

Signed-off-by: susanmdouglas <susandou@amazon.com>

### Description
I've updated the release notes for 2.1.0 (_includes/releases/babelfish-2.1.0.md) to remove mention of the backpatching of the CONCURRENTLY problem from the community, and updated the release date. We may or may not need to merge this change, but I'd like to have it on hand in case we need it.
 
### Issues Resolved
I've updated the release notes for 2.1.0 (_includes/releases/babelfish-2.1.0.md) to remove mention of the backpatching of the CONCURRENTLY problem from the community, and updated the release date. We may or may not need to merge this change, but I'd like to have it on hand in case we need it.

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
