### PR TITLE
Fix 2.1.1 and 1.3.1 displayed values for download links

### DIFF
--- a/_includes/releases/babelfish-1.3.1.md
+++ b/_includes/releases/babelfish-1.3.1.md
@@ -1,8 +1,8 @@
 - Babelfish Version: 1.3.1
 - PostgreSQL Server Version: 13.7
 - Download source distributions:
-  - [BABEL_1_3_1__PG_13_7.1.zip](https://github.com/babelfish-for-postgresql/babelfish-for-postgresql/releases/download/BABEL_1_3_1__PG_13_7/BABEL_1_3_0__PG_13_7.zip)
-  - [BABEL_1_3_1__PG_13_7.1.tar.gz](https://github.com/babelfish-for-postgresql/babelfish-for-postgresql/releases/download/BABEL_1_3_1__PG_13_7/BABEL_1_3_0__PG_13_7.tar.gz)
+  - [BABEL_1_3_1__PG_13_7.zip](https://github.com/babelfish-for-postgresql/babelfish-for-postgresql/releases/download/BABEL_1_3_1__PG_13_7/BABEL_1_3_0__PG_13_7.zip)
+  - [BABEL_1_3_1__PG_13_7.tar.gz](https://github.com/babelfish-for-postgresql/babelfish-for-postgresql/releases/download/BABEL_1_3_1__PG_13_7/BABEL_1_3_0__PG_13_7.tar.gz)
 - Babelfish Compass
   - [Download](https://github.com/babelfish-for-postgresql/babelfish_compass/releases)
 - Date: July 25, 2022

--- a/_includes/releases/babelfish-2.1.1.md
+++ b/_includes/releases/babelfish-2.1.1.md
@@ -1,11 +1,11 @@
 - Babelfish Version: 2.1.1
 - PostgreSQL Server Version: 14.3
 - Download source distributions:
-  - [BABEL_2_1_1__PG_14_3_1.zip](https://github.com/babelfish-for-postgresql/babelfish-for-postgresql/releases/download/BABEL_2_1_1__PG_14_3/BABEL_2_1_1__PG_14_3.zip)
-  - [BABEL_2_1_1__PG_14_3_1.tar.gz](https://github.com/babelfish-for-postgresql/babelfish-for-postgresql/releases/download/BABEL_2_1_1__PG_14_3/BABEL_2_1_1__PG_14_3.tar.gz)
+  - [BABEL_2_1_1__PG_14_3.zip](https://github.com/babelfish-for-postgresql/babelfish-for-postgresql/releases/download/BABEL_2_1_1__PG_14_3/BABEL_2_1_1__PG_14_3.zip)
+  - [BABEL_2_1_1__PG_14_3.tar.gz](https://github.com/babelfish-for-postgresql/babelfish-for-postgresql/releases/download/BABEL_2_1_1__PG_14_3/BABEL_2_1_1__PG_14_3.tar.gz)
 - Babelfish Compass
   - [Download](https://github.com/babelfish-for-postgresql/babelfish_compass/releases)
-- Date: July 25, 2022
+- Date: August 22, 2022
 
 ## Overview
 

--- a/index.markdown
+++ b/index.markdown
@@ -31,7 +31,7 @@ long_description: "Babelfish for PostgreSQL is an open source project available 
 callouts_head: "Principles for development"
 callouts_class: list-features
 callouts_id: principles
-callouts_leader: "When we (the contributors) are successful, Babelfish for PostgreSQL will be:"
+callouts_leader: "When the contributors are successful, Babelfish for PostgreSQL will be:"
 
 version_feature:
   latest_label: "Current Version:"
@@ -49,6 +49,8 @@ sidebar:
   - title: Releases
     description: List of Babelfish releases.
     links:
+      - title: Release 2.1.1
+        url: "/docs/versions/babelfish-2-1-1.html"
       - title: Release 2.1.0a
         url: "/docs/versions/babelfish-2-1-0a.html"
       - title: Release 2.1.0


### PR DESCRIPTION
### Description
This PR fixes the values displayed for the download links in the release notes, and adds the 2.1.1 release to the front page of the website.
 
### Issues Resolved
This PR fixes the values displayed for the download links in the release notes, and adds the 2.1.1 release to the front page of the website.

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
