### PR TITLE
DO NOT MERGE UNTIL 2.3.0 - Documentation for MVU

### DIFF
--- a/_usage/mvu.md
+++ b/_usage/mvu.md
@@ -6,7 +6,7 @@ nav_order: 9
 
 ## Babelfish Major Version Upgrade
 
-Babelfish for PostgreSQL now supports major version upgrade (MVU). The upgrade is composed of two main steps. You first perform a major version upgrade on the PostgreSQL server to upgrade it to the target version. And, then you update all Babelfish extensions to the target version. Currently, the Babelfish for PostgreSQL only supports upgrade using the `pg_upgrade` module. Other upgrade methods such as `dump`/`restore` and replication are not supported.
+Babelfish for PostgreSQL now supports major version upgrade (MVU). The upgrade is composed of two main steps. You first perform a major version upgrade on the PostgreSQL server to upgrade it to the target version. And, then you update all Babelfish extensions to the target version. Currently, Babelfish for PostgreSQL only supports upgrade using the `pg_upgrade` module. Other upgrade methods such as `dump`/`restore` and replication are not supported.
 
 ## Naming Conventions
 


### PR DESCRIPTION
This PR documents performing a major version upgrade to version 2.2.0; as of the first commit, the upgrade path is limited to 1.3.1 to 2.2.0.

Signed-off-by: susanmdouglas <susandou@amazon.com>

### Description
This PR documents performing a major version upgrade to version 2.2.0; as of the first commit, the upgrade path is limited to 1.3.1 to 2.2.0.
 
### Issues Resolved
This PR documents performing a major version upgrade to version 2.2.0; as of the first commit, the upgrade path is limited to 1.3.1 to 2.2.0.

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
