### PR TITLE
DO NOT MERGE UNTIL 2.3.0. - Babelfish support for hint mapping

### DIFF
--- a/_usage/hint_mapping.md
+++ b/_usage/hint_mapping.md
@@ -1,0 +1,58 @@
+---
+layout: default
+title: Using Hint Mapping
+nav_order: 9
+---
+
+## Using Query Hint Mapping
+
+Support for query hint mapping is available with Babelfish version 2.3.0. 
+
+Query optimizers do their best to select the best execution plan for your workload based on an engine’s cost model and column/table statistics, but real-world datasets show that query optimizers sometimes don't make the best choices. You can use a query hint to encourage the query optimizer to avoid performance issues caused by bad execution plans.  
+
+A query hint instructs the database engine how to execute a query. Babelfish can use the [pg_hint_plan](https://github.com/ossc-db/pg_hint_plan) extension to create and manage query hints.
+
+
+### Installing pg_hint_plan
+
+Babelfish version 2.3.0 supports version 1.4 of [pg_hint_plan](https://github.com/ossc-db/pg_hint_plan/releases/tag/REL14_1_4_0). To install pg_hint_plan:
+
+1. Download the  `pg_hint_plan14` module. 
+2. Navigate to the top of the source tree. 
+3. Assume the identity of the cluster owner, and run `make`, and then `make install`. 
+4. Modify your PATH environment variable to include the Babelfish PostgreSQL installation.
+
+You are not required to CREATE the pg_hint_plan extension, but you must either LOAD the extension.  Use the following command to load the extension for use in an individual session:
+
+```sql
+postgres=# LOAD 'pg_hint_plan';
+LOAD
+```
+
+Or, to enable the extension globally, add the extension to the end of the `shared_preload_libraries` parameter in the `postgresql.conf` and reload the parameters.
+
+
+### How to Turn on T-SQL Hints 
+
+By default, Babelfish ignores all T-SQL hints. To apply the supported T-SQL hints,  you need to use `sp_babelfish_configure` to turn on `enable_pg_hint` . Connect to the TDS listener port and run the following command:
+
+```sql
+EXEC sp_babelfish_configure 'enable_pg_hint', 'on' [, 'server'] 
+```
+
+Once `enable_pg_hint` is set to `ON`, Babelfish applies the following T-SQL hints:
+
+* `INDEX` hints
+* `JOIN` hints
+* `FORCE ORDER` hints
+* `MAXDOP` hints
+
+### Limitations
+
+- If a query plan is cached before `enable_pg_hint` is turned on, hints won’t be applied in the same session. If you create a new session, hints will be applied as expected.
+- If schema names are explicitly given, then hints cannot be applied. A workaround is to use table aliases.
+- Views and sub-queries cannot be hinted.
+- Hints do not work for `UPDATE`/`DELETE` statements with joins.
+- An index hint for a non-existing index or table is silently ignored.
+- `FORCE ORDER` hints do not work for HASH joins and non-ANSI joins.
+

--- a/_usage/hint_mapping.md
+++ b/_usage/hint_mapping.md
@@ -21,7 +21,7 @@ Babelfish version 2.3.0 supports version 1.4 of [pg_hint_plan](https://github.co
 2. At the top of the source tree, run `make` and then `make install`. 
 3. Modify your PATH environment variable to include the Babelfish PostgreSQL installation.
 
-You are not required to CREATE the pg_hint_plan extension, but you must either LOAD the extension.  Use the following command to load the extension for use in an individual session:
+You are not required to CREATE the pg_hint_plan extension, but you must LOAD the extension.  Use the following command at the psql command line to load the extension:
 
 ```sql
 postgres=# LOAD 'pg_hint_plan';

--- a/_usage/hint_mapping.md
+++ b/_usage/hint_mapping.md
@@ -4,52 +4,97 @@ title: Using Hint Mapping
 nav_order: 9
 ---
 
-## Using Query Hint Mapping
+## T-SQL query hints to improve Babelfish query performance
 
-Support for query hint mapping is available with Babelfish version 2.3.0. 
+Starting with version 2.3.0, Babelfish supports the use of T-SQL query hints using `pg_hint_plan`. For more information about the PostgreSQL extension `pg_hint_plan`, see (https://github.com/ossc-db/pg_hint_plan).
 
-Query optimizers do their best to select the best execution plan for your workload based on an engine’s cost model and column/table statistics, but real-world datasets show that query optimizers sometimes don't make the best choices. You can use a query hint to encourage the query optimizer to avoid performance issues caused by bad execution plans.  
+The PostgreSQL query optimizer is well-designed to find the optimal execution plan for a SQL statement. When selecting a plan, the query optimizer considers both the engine’s cost model, and column and table statistics. However, the suggested plan might not meet your needs. Thus, T-SQL query hints address the performance issues by helping the query optimizer improve execution plans. A query hint is syntax added to the SQL standard that instructs the database engine about how to execute the query. For example, a hint may instruct the engine to follow a sequential scan and override any plan that the query optimizer had selected.
 
-A query hint instructs the database engine how to execute a query. Babelfish can use the [pg_hint_plan](https://github.com/ossc-db/pg_hint_plan) extension to create and manage query hints.
+## Installing pg_hint_plan
+
+Babelfish version 2.3.0 supports version 1.4 of [`pg_hint_plan`](https://github.com/ossc-db/pg_hint_plan/releases/tag/REL14_1_4_0). To install `pg_hint_plan` please follow the instructions in (https://github.com/ossc-db/pg_hint_plan#building-binary-module).
 
 
-### Installing pg_hint_plan
+## Turning on T-SQL query hints in Babelfish
 
-Babelfish version 2.3.0 supports version 1.4 of [pg_hint_plan](https://github.com/ossc-db/pg_hint_plan/releases/tag/REL14_1_4_0). To install pg_hint_plan:
-
-1. Assume the identity of a sufficiently privileged user.
-2. At the top of the source tree, run `make` and then `make install`. 
-3. Modify your PATH environment variable to include the Babelfish PostgreSQL installation.
-
-You are not required to CREATE the pg_hint_plan extension, but you must LOAD the extension.  Use the following command at the psql command line to load the extension:
+Currently, Babelfish ignores all T-SQL hints by default. To apply T-SQL hints, run the command `sp_babelfish_configure` with the `enable_pg_hint` value as `ON`.
 
 ```sql
-postgres=# LOAD 'pg_hint_plan';
-LOAD
+EXECUTE sp_babelfish_configure 'enable_pg_hint', 'on' [, 'server']
 ```
 
+You can make the settings permanent on a cluster-wide level by including the `server` keyword. To configure the setting for the current session only, don't use server.
 
-### How to Turn on T-SQL Hints 
+After `enable_pg_hint` is `ON`, Babelfish applies the following T-SQL hints.
 
-By default, Babelfish ignores all T-SQL hints. To apply the supported T-SQL hints,  you need to use `sp_babelfish_configure` to turn on `enable_pg_hint` . Connect to the TDS listener port and run the following command:
+- INDEX hints
+
+- JOIN hints
+
+- FORCE ORDER hint
+
+- MAXDOP hint
+
+For example, the following command sequence turns on pg_hint_plan.
 
 ```sql
-EXEC sp_babelfish_configure 'enable_pg_hint', 'on' [, 'server'] 
+1> CREATE TABLE t1 (a1 INT PRIMARY KEY, b1 INT);
+2> CREATE TABLE t2 (a2 INT PRIMARY KEY, b2 INT);
+3> GO    
+1> EXECUTE sp_babelfish_configure 'enable_pg_hint', 'on';
+2> GO
+1> SET BABELFISH_SHOWPLAN_ALL ON;
+2> GO
+1> SELECT * FROM t1 JOIN t2 ON t1.a1 = t2.a2; --NO HINTS (HASH JOIN)
+2> GO
 ```
 
-Once `enable_pg_hint` is set to `ON`, Babelfish applies the following T-SQL hints:
+No hint is applied to the `SELECT` statement. The query plan with no hint is returned.
 
-* `INDEX` hints
-* `JOIN` hints
-* `FORCE ORDER` hints
-* `MAXDOP` hints
+```sql
+QUERY PLAN                                                                                                                                                                                                                                
+---------------------------------------------------------------------------
+Query Text: SELECT * FROM t1 JOIN t2 ON t1.a1 = t2.a2
+Hash Join (cost=60.85..99.39 rows=2260 width=16)
+ Hash Cond: (t1.a1 = t2.a2)
+ -> Seq Scan on t1 (cost=0.00..32.60 rows=2260 width=8)
+ -> Hash (cost=32.60..32.60 rows=2260 width=8)
+ -> Seq Scan on t2 (cost=0.00..32.60 rows=2260 width=8)
+```
 
-### Limitations
+```sql
+1> SELECT * FROM t1 INNER MERGE JOIN t2 ON t1.a1 = t2.a2;
+2> GO
+```    
+ The query hint is applied to the `SELECT` statement. The following output shows that the query plan with merge join is returned.
 
-- If a query plan is cached before `enable_pg_hint` is turned on, hints won’t be applied in the same session. If you create a new session, hints will be applied as expected.
-- If schema names are explicitly given, then hints cannot be applied. A workaround is to use table aliases.
-- Views and sub-queries cannot be hinted.
-- Hints do not work for `UPDATE`/`DELETE` statements with joins.
-- An index hint for a non-existing index or table is silently ignored.
-- `FORCE ORDER` hints do not work for HASH joins and non-ANSI joins.
+```sql
+QUERY PLAN                                                                                                                                                                                                                                
+---------------------------------------------------------------------------
+Query Text: SELECT/*+ MergeJoin(t1 t2) Leading(t1 t2)*/ * FROM t1 INNER JOIN t2 ON t1.a1 = t2.a2
+Merge Join (cost=0.31..190.01 rows=2260 width=16)
+ Merge Cond: (t1.a1 = t2.a2)
+ -> Index Scan using t1_pkey on t1 (cost=0.15..78.06 rows=2260 width=8)
+ -> Index Scan using t2_pkey on t2 (cost=0.15..78.06 rows=2260 width=8)
+```
 
+```sql
+1> SET BABELFISH_SHOWPLAN_ALL OFF;
+2> GO
+```
+
+##Limitations
+
+While using the query hints, consider the following limitations:
+
+- If a query plan is cached before enable_pg_hint is turned on, hints won't be applied in the same session. It will be applied in the new session .
+
+- If schema names are explicitly given, then hints can't be applied. You can use table aliases as a workaround.
+
+- A query hint can't be applied to views and sub-queries.
+
+- Hints don't work for UPDATE/DELETE statements with JOINs.
+
+- An index hint for a non-existing index or table is ignored.
+
+- The FORCE ORDER hint doesn't work for HASH JOINs and non-ANSI JOINs.

--- a/_usage/hint_mapping.md
+++ b/_usage/hint_mapping.md
@@ -17,10 +17,9 @@ A query hint instructs the database engine how to execute a query. Babelfish can
 
 Babelfish version 2.3.0 supports version 1.4 of [pg_hint_plan](https://github.com/ossc-db/pg_hint_plan/releases/tag/REL14_1_4_0). To install pg_hint_plan:
 
-1. Download the  `pg_hint_plan14` module. 
-2. Navigate to the top of the source tree. 
-3. Assume the identity of the cluster owner, and run `make`, and then `make install`. 
-4. Modify your PATH environment variable to include the Babelfish PostgreSQL installation.
+1. Assume the identity of a sufficiently privileged user.
+2. At the top of the source tree, run `make` and then `make install`. 
+3. Modify your PATH environment variable to include the Babelfish PostgreSQL installation.
 
 You are not required to CREATE the pg_hint_plan extension, but you must either LOAD the extension.  Use the following command to load the extension for use in an individual session:
 
@@ -28,8 +27,6 @@ You are not required to CREATE the pg_hint_plan extension, but you must either L
 postgres=# LOAD 'pg_hint_plan';
 LOAD
 ```
-
-Or, to enable the extension globally, add the extension to the end of the `shared_preload_libraries` parameter in the `postgresql.conf` and reload the parameters.
 
 
 ### How to Turn on T-SQL Hints 


### PR DESCRIPTION
Initial check in of hint mapping for 2.3.0

Signed-off-by: susanmdouglas <susandou@amazon.com>

### Description
Initial check in of hint mapping for 2.3.0
 
### Issues Resolved
Initial check in of hint mapping for 2.3.0

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
