### PR TITLE
Updated locales.md for typos

### DIFF
--- a/_usage/locales.md
+++ b/_usage/locales.md
@@ -172,7 +172,7 @@ postgres=# \dO
 Connect to the T-SQL port (by default `1433`) and enter:
 
 ```sql
-SELECT * FROM fn_helpcollation();
+SELECT * FROM fn_helpcollations();
 ```
 
 


### PR DESCRIPTION
Signed-off-by: vasavi suthapalli <svasusri@amazon.com>

### Description
Updated locales.md to correct sentence from 'SELECT * FROM fn_helpcollation();' to 'SELECT * FROM fn_helpcollations();'



### Check List
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
